### PR TITLE
Github Actions: Update Node.js version in workflows

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test code and Create Test Coverage Reports
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14
+          node-version-file: '.nvmrc'
           cache: npm
       - run: |
           npm ci

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
 
       # Ensure tests pass. Add more checks if required


### PR DESCRIPTION
Its better to let github actions use .nvmrc to determine the node version to use in the workflows. This helps with ensuring that github actions are using the same node version as the local development environment.

As you can see already the node versions were different from nvmrc which is specifically using 22.11.0