### PR TITLE
Rps 541 improve payment hub request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "nunjucks": "^3.2.4",
         "pino": "^9.5.0",
         "pino-pretty": "^13.0.0",
-        "undici": "^6.20.1"
+        "undici": "^6.20.1",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -12658,6 +12659,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "nunjucks": "^3.2.4",
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
-    "undici": "^6.20.1"
+    "undici": "^6.20.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.9",

--- a/src/api/agreement/helpers/create-invoice.js
+++ b/src/api/agreement/helpers/create-invoice.js
@@ -1,0 +1,32 @@
+import Boom from '@hapi/boom'
+import invoicesModel from '~/src/api/common/models/invoices.js'
+import { v4 as uuidv4 } from 'uuid'
+
+/**
+ * Create a new invoice for the given agreement ID
+ * @returns {object} The agreement data
+ * @param {string} agreementId - The agreement ID to fetch
+ * @returns {Invoice}
+ */
+async function createInvoice(agreementId) {
+  const index = (await invoicesModel.find({})).length
+  const invoice = await invoicesModel
+    .create({
+      agreementNumber: agreementId,
+      invoiceNumber: `FRPS${index + 1}`,
+      correlationId: uuidv4()
+    })
+    .catch((error) => {
+      throw Boom.internal(error)
+    })
+
+  if (!invoice) {
+    throw Boom.notFound(`Invoice not created for Agreement ID ${agreementId}`)
+  }
+
+  return invoice
+}
+
+export { createInvoice }
+
+/** @import { Invoice } from '~/src/api/common/types/invoice.d.js' */

--- a/src/api/agreement/helpers/create-invoice.test.js
+++ b/src/api/agreement/helpers/create-invoice.test.js
@@ -1,0 +1,119 @@
+import { jest } from '@jest/globals'
+import { createInvoice } from './create-invoice.js'
+import invoicesModel from '~/src/api/common/models/invoices.js'
+import Boom from '@hapi/boom'
+import { v4 as uuidv4 } from 'uuid'
+
+// Mock dependencies
+jest.mock('~/src/api/common/models/invoices.js')
+jest.mock('uuid')
+
+describe('createInvoice', () => {
+  const mockUuid = '123e4567-e89b-12d3-a456-426614174000'
+  const mockAgreementId = 'SFI123456789'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    // Mock uuid generation
+    uuidv4.mockReturnValue(mockUuid)
+
+    // Default mock for invoicesModel.find
+    invoicesModel.find.mockResolvedValue([{}, {}, {}]) // 3 existing invoices
+  })
+
+  it('should create a new invoice with correct data', async () => {
+    // Arrange
+    const mockInvoice = {
+      agreementNumber: mockAgreementId,
+      invoiceNumber: 'FRPS3',
+      correlationId: mockUuid
+    }
+
+    invoicesModel.create.mockResolvedValue(mockInvoice)
+
+    // Act
+    const result = await createInvoice(mockAgreementId)
+
+    // Assert
+    expect(invoicesModel.find).toHaveBeenCalledWith({})
+    expect(invoicesModel.create).toHaveBeenCalledWith({
+      agreementNumber: mockAgreementId,
+      invoiceNumber: 'FRPS4', // Index is 3 because we mocked 3 existing invoices
+      correlationId: mockUuid
+    })
+    expect(result).toEqual(mockInvoice)
+  })
+
+  it('should generate invoice numbers sequentially based on existing invoices', async () => {
+    // Arrange - mock different existing invoice counts
+    invoicesModel.find.mockResolvedValue([]) // 0 existing invoices
+
+    const mockInvoice = {
+      agreementNumber: mockAgreementId,
+      invoiceNumber: 'FRPS0',
+      correlationId: mockUuid
+    }
+
+    invoicesModel.create.mockResolvedValue(mockInvoice)
+
+    // Act
+    const result = await createInvoice(mockAgreementId)
+
+    // Assert
+    expect(invoicesModel.create).toHaveBeenCalledWith({
+      agreementNumber: mockAgreementId,
+      invoiceNumber: 'FRPS1', // Index is 0 because we mocked 0 existing invoices
+      correlationId: mockUuid
+    })
+    expect(result).toEqual(mockInvoice)
+  })
+
+  it('should throw Boom.internal if invoicesModel.create throws an error', async () => {
+    // Arrange
+    const mockError = new Error('Database error')
+    invoicesModel.create.mockRejectedValue(mockError)
+
+    // Act & Assert
+    await expect(createInvoice(mockAgreementId)).rejects.toThrow(
+      Boom.internal(mockError).message
+    )
+  })
+
+  it('should throw Boom.notFound if invoicesModel.create returns falsy value', async () => {
+    // Arrange
+    invoicesModel.create.mockResolvedValue(null)
+
+    // Act & Assert
+    await expect(createInvoice(mockAgreementId)).rejects.toThrow(
+      Boom.notFound(`Invoice not created for Agreement ID ${mockAgreementId}`)
+        .message
+    )
+  })
+
+  it('should handle large number of existing invoices', async () => {
+    // Arrange - mock a large number of existing invoices
+    const largeNumber = 9999
+    const mockInvoices = Array(largeNumber).fill({})
+    invoicesModel.find.mockResolvedValue(mockInvoices)
+
+    const mockInvoice = {
+      agreementNumber: mockAgreementId,
+      invoiceNumber: `FRPS${largeNumber}`,
+      correlationId: mockUuid
+    }
+
+    invoicesModel.create.mockResolvedValue(mockInvoice)
+
+    // Act
+    const result = await createInvoice(mockAgreementId)
+
+    // Assert
+    expect(invoicesModel.create).toHaveBeenCalledWith({
+      agreementNumber: mockAgreementId,
+      invoiceNumber: `FRPS10000`,
+      correlationId: mockUuid
+    })
+    expect(result).toEqual(mockInvoice)
+  })
+})

--- a/src/api/agreement/helpers/update-payment-hub.js
+++ b/src/api/agreement/helpers/update-payment-hub.js
@@ -1,4 +1,5 @@
 import Boom from '@hapi/boom'
+import { v4 as uuidv4 } from 'uuid'
 import { getAgreementData } from '~/src/api/agreement/helpers/get-agreement-data.js'
 import { sendPaymentHubRequest } from '~/src/api/common/helpers/payment-hub/index.js'
 
@@ -17,18 +18,20 @@ async function updatePaymentHub({ server, logger }, agreementId) {
       throw Boom.notFound(`Agreement not found: ${agreementId}`)
     }
 
+    const marketingYear = new Date().getFullYear()
+
     // Construct the payload based on the agreement data
     /** @type {PaymentHubPayload} */
     const payload = {
       sourceSystem: 'FRPS',
-      frn: 1234567890,
-      sbi: 123456789,
-      marketingYear: 2025,
+      frn: agreementData.frn,
+      sbi: agreementData.sbi,
+      marketingYear,
       paymentRequestNumber: 1,
       paymentType: 1,
-      correlationId: '123e4567-e89b-12d3-a456-426655440000',
+      correlationId: uuidv4(),
       invoiceNumber: 'S1234567S1234567V001',
-      agreementNumber: 'SFI12345678',
+      agreementNumber: agreementData.agreementNumber,
       contractNumber: 'S1234567',
       currency: 'GBP',
       schedule: 'T4',
@@ -37,9 +40,6 @@ async function updatePaymentHub({ server, logger }, agreementId) {
       debtType: 'irr',
       recoveryDate: '09/11/2021',
       pillar: 'DA',
-      originalInvoiceNumber: 'S1234567S1234567V001',
-      originalSettlementDate: '09/11/2021',
-      invoiceCorrectionReference: 'S1234567S1234567V001',
       trader: '123456A',
       vendor: '123456A',
       invoiceLines: [
@@ -50,7 +50,7 @@ async function updatePaymentHub({ server, logger }, agreementId) {
           standardCode: 'frps-cows',
           accountCode: 'SOS123',
           deliveryBody: 'RP00',
-          marketingYear: 2022,
+          marketingYear,
           convergence: false,
           stateAid: false
         }

--- a/src/api/agreement/helpers/update-payment-hub.js
+++ b/src/api/agreement/helpers/update-payment-hub.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom'
-import { v4 as uuidv4 } from 'uuid'
 import { getAgreementData } from '~/src/api/agreement/helpers/get-agreement-data.js'
+import { createInvoice } from '~/src/api/agreement/helpers/create-invoice.js'
 import { sendPaymentHubRequest } from '~/src/api/common/helpers/payment-hub/index.js'
 
 /**
@@ -13,6 +13,7 @@ import { sendPaymentHubRequest } from '~/src/api/common/helpers/payment-hub/inde
 async function updatePaymentHub({ server, logger }, agreementId) {
   try {
     const agreementData = await getAgreementData(agreementId)
+    const invoice = await createInvoice(agreementId)
 
     if (!agreementData) {
       throw Boom.notFound(`Agreement not found: ${agreementId}`)
@@ -29,22 +30,20 @@ async function updatePaymentHub({ server, logger }, agreementId) {
       marketingYear,
       paymentRequestNumber: 1,
       paymentType: 1,
-      correlationId: uuidv4(),
-      invoiceNumber: 'S1234567S1234567V001',
+      correlationId: invoice.correlationId,
+      invoiceNumber: invoice.invoiceNumber,
       agreementNumber: agreementData.agreementNumber,
       contractNumber: 'S1234567',
       currency: 'GBP',
       schedule: 'T4',
-      dueDate: '09/11/2022',
-      value: 500,
+      value: agreementData.payments.totalAnnualPayment.totalAnnualPayment,
       debtType: 'irr',
-      recoveryDate: '09/11/2021',
       pillar: 'DA',
       trader: '123456A',
       vendor: '123456A',
       invoiceLines: [
         {
-          value: 500,
+          value: agreementData.payments.totalAnnualPayment.totalAnnualPayment,
           description: 'G00 - Gross value of agreement',
           schemeCode: 'A1234',
           standardCode: 'frps-cows',

--- a/src/api/agreement/helpers/update-payment-hub.test.js
+++ b/src/api/agreement/helpers/update-payment-hub.test.js
@@ -1,32 +1,59 @@
 import { updatePaymentHub } from '~/src/api/agreement/helpers/update-payment-hub.js'
 import { getAgreementData } from '~/src/api/agreement/helpers/get-agreement-data.js'
 import { sendPaymentHubRequest } from '~/src/api/common/helpers/payment-hub/index.js'
+import { createInvoice } from '~/src/api/agreement/helpers/create-invoice.js'
 import Boom from '@hapi/boom'
 
 jest.mock('~/src/api/agreement/helpers/get-agreement-data.js')
 jest.mock('~/src/api/common/helpers/payment-hub/index.js')
+jest.mock('~/src/api/agreement/helpers/create-invoice.js')
 
 describe('updatePaymentHub', () => {
-  const logger = { info: jest.fn(), error: jest.fn() }
+  const request = {
+    server: jest.fn(),
+    logger: { info: jest.fn(), error: jest.fn() }
+  }
   const mockAgreementData = {
     agreementNumber: 'SFI123456789',
-    sbi: 123456789
+    sbi: 123456789,
+    frn: 123456789,
+    payments: {
+      totalAnnualPayment: {
+        totalAnnualPayment: 500
+      }
+    }
+  }
+  const mockInvoice = {
+    agreementNumber: 'SFI123456789',
+    invoiceNumber: 'FRPS123',
+    correlationId: '123e4567-e89b-12d3-a456-426614174000'
   }
 
   beforeEach(() => {
     jest.clearAllMocks()
     getAgreementData.mockResolvedValue(mockAgreementData)
     sendPaymentHubRequest.mockResolvedValue({ status: 'success' })
+    createInvoice.mockResolvedValue(mockInvoice)
   })
 
   test('should send payload to payment hub', async () => {
     const agreementId = 'SFI123456789'
 
     // Act
-    const result = await updatePaymentHub(agreementId, logger)
+    const result = await updatePaymentHub(request, agreementId)
 
     // Assert
+    expect(createInvoice).toHaveBeenCalledWith(agreementId)
     expect(sendPaymentHubRequest).toHaveBeenCalledTimes(1)
+    expect(sendPaymentHubRequest).toHaveBeenCalledWith(
+      request.server,
+      request.logger,
+      expect.objectContaining({
+        agreementNumber: mockAgreementData.agreementNumber,
+        invoiceNumber: mockInvoice.invoiceNumber,
+        correlationId: mockInvoice.correlationId
+      })
+    )
     expect(result).toEqual({
       status: 'success',
       message: 'Payload sent to payment hub successfully'
@@ -41,7 +68,7 @@ describe('updatePaymentHub', () => {
     )
 
     // Act & Assert
-    await expect(updatePaymentHub(agreementId, logger)).rejects.toThrow(
+    await expect(updatePaymentHub(request, agreementId)).rejects.toThrow(
       'Internal Server Error'
     )
   })
@@ -52,7 +79,7 @@ describe('updatePaymentHub', () => {
     getAgreementData.mockRejectedValueOnce(Boom.notFound('Agreement not found'))
 
     // Act & Assert
-    await expect(updatePaymentHub(agreementId, logger)).rejects.toThrow(
+    await expect(updatePaymentHub(request, agreementId)).rejects.toThrow(
       'Agreement not found'
     )
   })
@@ -63,8 +90,42 @@ describe('updatePaymentHub', () => {
     sendPaymentHubRequest.mockRejectedValueOnce(new Error('Network error'))
 
     // Act & Assert
-    await expect(updatePaymentHub(agreementId, logger)).rejects.toThrow(
+    await expect(updatePaymentHub(request, agreementId)).rejects.toThrow(
       'Network error'
+    )
+  })
+
+  test('should throw an error if invoice creation fails', async () => {
+    // Arrange
+    const agreementId = 'SFI123456789'
+    const invoiceError = new Error('Failed to create invoice')
+    createInvoice.mockRejectedValueOnce(invoiceError)
+
+    // Act & Assert
+    await expect(updatePaymentHub(request, agreementId)).rejects.toThrow(
+      'Failed to create invoice'
+    )
+    expect(sendPaymentHubRequest).not.toHaveBeenCalled()
+  })
+
+  test('should include invoice data in the payment hub payload', async () => {
+    // Arrange
+    const agreementId = 'SFI123456789'
+
+    // Act
+    await updatePaymentHub(request, agreementId)
+
+    // Assert
+    expect(sendPaymentHubRequest).toHaveBeenCalledWith(
+      request.server,
+      request.logger,
+      expect.objectContaining({
+        agreementNumber: mockAgreementData.agreementNumber,
+        invoiceNumber: mockInvoice.invoiceNumber,
+        correlationId: mockInvoice.correlationId,
+        sbi: mockAgreementData.sbi,
+        frn: mockAgreementData.frn
+      })
     )
   })
 })

--- a/src/api/common/helpers/sample-data/agreements.js
+++ b/src/api/common/helpers/sample-data/agreements.js
@@ -13,6 +13,7 @@ export default [
   {
     agreementNumber: 'SFI987654321',
     agreementName: 'Sample Agreement',
+    frn: '9876543210',
     sbi: '117235001',
     company: 'Sample Farm Ltd',
     address: '123 Farm Lane, Farmville',
@@ -71,6 +72,7 @@ export default [
   {
     agreementNumber: 'SFI123456789',
     agreementName: 'Sample Agreement',
+    frn: '1234567890',
     sbi: '123456789',
     company: 'Sample Farm Ltd',
     address: '123 Farm Lane, Farmville',

--- a/src/api/common/helpers/seed-database.js
+++ b/src/api/common/helpers/seed-database.js
@@ -16,13 +16,15 @@ export async function seedDatabase(logger) {
 
       logger.info(`Dropped collection '${name}'`)
 
-      await model.insertMany(data[name]).catch((e) => {
-        logger.error(e)
-      })
+      if (data[name]) {
+        await model.insertMany(data[name]).catch((e) => {
+          logger.error(e)
+        })
 
-      logger.info(
-        `Successfully inserted ${data[name].length} documents into the '${name}' collection`
-      )
+        logger.info(
+          `Successfully inserted ${data[name].length} documents into the '${name}' collection`
+        )
+      }
     } catch (e) {
       logger.error(e)
     }

--- a/src/api/common/models/index.js
+++ b/src/api/common/models/index.js
@@ -1,5 +1,7 @@
 import agreements from './agreements.js'
+import invoices from './invoices.js'
 
 export default {
-  agreements
+  agreements,
+  invoices
 }

--- a/src/api/common/models/invoices.js
+++ b/src/api/common/models/invoices.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose'
+
+const collection = 'invoices'
+
+const schema = new mongoose.Schema(
+  {
+    agreementNumber: { type: String, required: true },
+    invoiceNumber: { type: String, required: true },
+    correlationId: { type: String, required: true }
+  },
+  {
+    collection,
+    timestamps: true
+  }
+)
+
+// Indexes for common queries
+schema.index({ agreementNumber: 1 }, { unique: true })
+schema.index({ invoiceNumber: 1 }, { unique: true })
+schema.index({ correlationId: 1 }, { unique: true })
+
+export default mongoose.model(collection, schema)

--- a/src/api/common/models/invoices.js
+++ b/src/api/common/models/invoices.js
@@ -15,7 +15,7 @@ const schema = new mongoose.Schema(
 )
 
 // Indexes for common queries
-schema.index({ agreementNumber: 1 }, { unique: true })
+schema.index({ agreementNumber: 1 })
 schema.index({ invoiceNumber: 1 }, { unique: true })
 schema.index({ correlationId: 1 }, { unique: true })
 

--- a/src/api/common/types/invoice.d.js
+++ b/src/api/common/types/invoice.d.js
@@ -1,0 +1,6 @@
+/**
+ * @typedef {object} Invoice
+ * @property {string} agreementId - ID of the agreement this invoice is for
+ * @property {string} invoiceId - The invoice ID
+ * @property {string} correlationId - The correlation ID for tracking
+ */

--- a/src/api/common/types/payment-hub.d.js
+++ b/src/api/common/types/payment-hub.d.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {object} PaymentHubPayload
  * @property {string} sourceSystem - The source system identifier.
- * @property {number} frn - The farmer reference number.
+ * @property {number} frn - The firm reference number.
  * @property {number} sbi - The single business identifier.
  * @property {number} marketingYear - The marketing year.
  * @property {number} paymentRequestNumber - The payment request number.


### PR DESCRIPTION
How to test this PR:
- Pull the branch locally
- Run from the command line with `SEED_DB=true npm run dev`
- Navigate to `http://localhost:3001/agreement/SFI123456789`
- Accept the agreement
- Observe Payment Hub request in the terminal. Make a note of the invoice number (should be FRPS1) and a correlation ID
- Use Postman to make a POST request to `http://localhost:3001/api/agreement/SFI123456789/unaccept`
- Navigate back to `http://localhost:3001/agreement/SFI123456789`
- Accept the agreement
- Observe Payment Hub request in the terminal. Make a note of the invoice number (should be FRPS2) with a different correlation ID
- You should be able to see both invoices in MongoDB