### PR TITLE
added payment-hub message logging to lower environments

### DIFF
--- a/src/api/common/helpers/payment-hub/index.js
+++ b/src/api/common/helpers/payment-hub/index.js
@@ -69,7 +69,11 @@ const proxyFetch = (url, options) => {
  */
 export const sendPaymentHubRequest = async (server, logger, body) => {
   // Log payload in all environments except production
-  if (process.env.NODE_ENV !== 'production') {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    logger &&
+    typeof logger.info === 'function'
+  ) {
     logger.info(
       `Payload to be sent to payment hub: ${JSON.stringify(body, null, 2)}`
     )

--- a/src/api/common/helpers/payment-hub/index.js
+++ b/src/api/common/helpers/payment-hub/index.js
@@ -68,11 +68,14 @@ const proxyFetch = (url, options) => {
  * @returns {Promise<object>} The response from the payment hub
  */
 export const sendPaymentHubRequest = async (server, logger, body) => {
-  if (config.get('env') === 'development') {
+  // Log payload in all environments except production
+  if (process.env.NODE_ENV !== 'production') {
     logger.info(
       `Payload to be sent to payment hub: ${JSON.stringify(body, null, 2)}`
     )
+  }
 
+  if (config.get('env') === 'development') {
     return {
       status: 'success',
       message: 'Payload sent to payment hub successfully'


### PR DESCRIPTION
* Log payment hub payload in all non-production environments.
* Skips logging in production +a defensive check - only log the payload if a logger with an info method is provided, to prevent errors if logger is missing.
* No change to message delivery logic.

