### PR TITLE
Fix failing start server unit test

### DIFF
--- a/src/api/common/helpers/start-server.js
+++ b/src/api/common/helpers/start-server.js
@@ -3,11 +3,11 @@ import { config } from '~/src/config/index.js'
 import { createServer } from '~/src/api/index.js'
 import { createLogger } from '~/src/api/common/helpers/logging/logger.js'
 
-async function startServer() {
+async function startServer(options = {}) {
   let server
 
   try {
-    server = await createServer()
+    server = await createServer(options)
     await server.start()
 
     server.logger.info('Server started successfully')


### PR DESCRIPTION
`Should start up server as expected` was failing as it expected there to be a `logger.warn(...)` function and `.startServer({ disableSQS: true })` was not being set correctly