### PR TITLE
FRPSSFI-238 Verify 'x-encrypted-auth' header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@hapi/catbox-memory": "^6.0.2",
         "@hapi/hapi": "^21.3.12",
         "@hapi/inert": "^7.1.0",
+        "@hapi/jwt": "^3.2.0",
         "@hapi/vision": "^7.0.3",
         "aws-embedded-metrics": "^4.2.0",
         "aws4": "^1.13.2",
@@ -3285,6 +3286,16 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hapi/catbox-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-object/-/catbox-object-3.0.1.tgz",
+      "integrity": "sha512-3w6E2DXtjWbmLYi4WcFUOor5jgrXN4PWhDrMrXKP/cEsFSfVSRJ0FhY2PXrhrUHwcllfKezYafWU3tQ5+8RO1w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@hapi/content": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
@@ -3393,6 +3404,30 @@
         "@hapi/cryptiles": "^6.0.1",
         "@hapi/hoek": "^11.0.2"
       }
+    },
+    "node_modules/@hapi/jwt": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/jwt/-/jwt-3.2.0.tgz",
+      "integrity": "sha512-2EU5zdr0petG63J2RHiagGByA1Qr6qzxMmrJJ3/0cm78be1Lq4vi038YgKJvbBSxSboIp5SWGZdYB6+CJlqEoQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/catbox-object": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/wreck": "^18.0.0",
+        "ecdsa-sig-formatter": "^1.0.0",
+        "joi": "^17.2.1"
+      }
+    },
+    "node_modules/@hapi/jwt/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/mimos": {
       "version": "7.0.1",
@@ -7554,6 +7589,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@hapi/catbox-memory": "^6.0.2",
     "@hapi/hapi": "^21.3.12",
     "@hapi/inert": "^7.1.0",
+    "@hapi/jwt": "^3.2.0",
     "@hapi/vision": "^7.0.3",
     "aws-embedded-metrics": "^4.2.0",
     "aws4": "^1.13.2",

--- a/src/api/agreement/controllers/view-agreement.controller.js
+++ b/src/api/agreement/controllers/view-agreement.controller.js
@@ -1,5 +1,50 @@
+import { config } from '~/src/config/index.js'
 import { statusCodes } from '~/src/api/common/constants/status-codes.js'
 import { getHTMLAgreementDocument } from '~/src/api/agreement/helpers/get-html-agreement.js'
+import { getAgreementData } from '~/src/api/agreement/helpers/get-agreement-data.js'
+import Jwt from '@hapi/jwt'
+
+/**
+ * Validates and verifies a JWT token against a secret to extract the payload
+ * which will have the 'sbi' and 'source' data
+ *
+ * @param {string} authToken - The JWT token to verify and decode
+ * @param {object} logger - Logger instance for error reporting
+ * @returns {payload|null} The JWT payload object from the token or null if invalid/missing
+ */
+const extractPayload = (authToken, logger) => {
+  if (!authToken || authToken.trim() === '') {
+    logger.error('No JWT token provided')
+    return null
+  }
+
+  try {
+    const decoded = Jwt.token.decode(authToken)
+    // Verify the token against the secret
+    Jwt.token.verify(decoded, {
+      key: config.get('jwtToken'),
+      algorithms: ['HS256']
+    })
+    return decoded?.decoded?.payload || null
+  } catch (jwtError) {
+    logger.error(`Invalid JWT token provided: ${jwtError.message}`)
+    logger.error(jwtError.stack)
+    return null
+  }
+}
+
+/**
+ *
+ * @param {object} jwtPayload - The Jwt Auth payload, that has 'sbi' and 'source'
+ * @param {object} agreementData - The agreement data object
+ * @returns {boolean} - if the auth payload could be verified against the sbi from the agreementData
+ */
+const verifyJwtPayload = (jwtPayload, agreementData) => {
+  if (jwtPayload?.source === 'entra') {
+    return true
+  }
+  return jwtPayload.source === 'defra' && jwtPayload.sbi === agreementData.sbi
+}
 
 /**
  * Controller to serve HTML agreement document
@@ -11,6 +56,23 @@ const viewAgreementController = {
     try {
       const { agreementId } = request.params
 
+      // Extract SBI from JWT token
+      const jwtPayload = extractPayload(
+        request.headers['x-encrypted-auth'],
+        request.logger
+      )
+
+      const agreementData = await getAgreementData({
+        agreementNumber: agreementId
+      })
+      if (!jwtPayload || !verifyJwtPayload(jwtPayload, agreementData)) {
+        return h
+          .response({
+            message: 'Not authorized to view offer agreement document'
+          })
+          .code(statusCodes.unauthorized)
+      }
+
       request.logger.info(
         `Rendering HTML agreement document for agreementId: ${agreementId}`
       )
@@ -18,7 +80,7 @@ const viewAgreementController = {
       // get HTML agreement
       const renderedHtml = await getHTMLAgreementDocument(
         agreementId,
-        null,
+        agreementData,
         request.headers['defra-grants-proxy'] === 'true'
       )
 

--- a/src/api/agreement/controllers/view-agreement.controller.test.js
+++ b/src/api/agreement/controllers/view-agreement.controller.test.js
@@ -1,18 +1,25 @@
 import { createServer } from '~/src/api/index.js'
 import { statusCodes } from '~/src/api/common/constants/status-codes.js'
-import * as nunjucksRenderer from '~/src/api/agreement/helpers/nunjucks-renderer.js'
 import * as agreementDataHelper from '~/src/api/agreement/helpers/get-agreement-data.js'
+import * as getHTMLAgreement from '~/src/api/agreement/helpers/get-html-agreement.js'
+import Jwt from '@hapi/jwt'
 
 // Mock the modules
 jest.mock('~/src/api/common/helpers/sqs-client.js')
 jest.mock('~/src/api/agreement/helpers/nunjucks-renderer.js')
 jest.mock('~/src/api/agreement/helpers/get-agreement-data.js')
+jest.mock('~/src/api/agreement/helpers/get-html-agreement.js')
+jest.mock('@hapi/jwt')
 
 describe('viewAgreementController', () => {
   /** @type {import('@hapi/hapi').Server} */
   let server
 
   const mockRenderedHtml = `<html><body>Test HTML with SFI123456789</body></html>`
+  const mockAgreementData = {
+    sbi: '123456789',
+    agreementNumber: 'SFI123456789'
+  }
 
   beforeAll(async () => {
     server = await createServer({ disableSQS: true })
@@ -26,16 +33,40 @@ describe('viewAgreementController', () => {
   beforeEach(() => {
     // Reset mocks before each test
     jest.clearAllMocks()
+
+    // Mock default successful responses for all tests
+    jest
+      .spyOn(agreementDataHelper, 'getAgreementData')
+      .mockResolvedValue(mockAgreementData)
+
+    jest
+      .spyOn(getHTMLAgreement, 'getHTMLAgreementDocument')
+      .mockResolvedValue(mockRenderedHtml)
+
+    Jwt.token.verify = jest.fn().mockImplementation(() => Promise.resolve())
+
+    // Mock JWT decode to return a valid Defra token by default
+    Jwt.token.decode = jest.fn().mockReturnValue({
+      decoded: {
+        payload: {
+          sbi: '123456789',
+          source: 'defra'
+        }
+      }
+    })
   })
 
-  test('Should return HTML when valid agreement ID is provided', async () => {
+  test('Should return HTML when valid agreement ID and valid auth are provided', async () => {
     // Arrange
     const agreementId = 'SFI123456789'
 
     // Act
     const { statusCode, headers, payload } = await server.inject({
       method: 'GET',
-      url: `/view-agreement/${agreementId}`
+      url: `/view-agreement/${agreementId}`,
+      headers: {
+        'x-encrypted-auth': 'valid-jwt-token'
+      }
     })
 
     // Assert
@@ -47,11 +78,10 @@ describe('viewAgreementController', () => {
     expect(agreementDataHelper.getAgreementData).toHaveBeenCalledWith({
       agreementNumber: agreementId
     })
-    expect(nunjucksRenderer.renderTemplate).toHaveBeenCalledWith(
-      'views/sfi-agreement.njk',
-      expect.objectContaining({
-        agreementNumber: agreementId
-      })
+    expect(getHTMLAgreement.getHTMLAgreementDocument).toHaveBeenCalledWith(
+      agreementId,
+      mockAgreementData,
+      false
     )
   })
 
@@ -59,7 +89,10 @@ describe('viewAgreementController', () => {
     // Act
     const { statusCode, headers, payload } = await server.inject({
       method: 'GET',
-      url: '/view-agreement/undefined'
+      url: '/view-agreement/undefined',
+      headers: {
+        'x-encrypted-auth': 'valid-jwt-token'
+      }
     })
 
     // Assert
@@ -76,14 +109,17 @@ describe('viewAgreementController', () => {
   test('Should handle error when template rendering fails', async () => {
     // Arrange
     const errorMessage = 'Failed to render HTML'
-    jest.spyOn(nunjucksRenderer, 'renderTemplate').mockImplementation(() => {
-      throw new Error(errorMessage)
-    })
+    jest
+      .spyOn(getHTMLAgreement, 'getHTMLAgreementDocument')
+      .mockRejectedValue(new Error(errorMessage))
 
     // Act
     const { statusCode, result } = await server.inject({
       method: 'GET',
-      url: '/view-agreement/SFI123456789'
+      url: '/view-agreement/SFI123456789',
+      headers: {
+        'x-encrypted-auth': 'valid-jwt-token'
+      }
     })
 
     // Assert
@@ -114,6 +150,201 @@ describe('viewAgreementController', () => {
     expect(result).toEqual({
       message: 'Failed to generate agreement document',
       error: errorMessage
+    })
+  })
+
+  // JWT Authorization Tests
+  describe('JWT Authorization', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+
+      // Mock default successful responses
+      jest
+        .spyOn(agreementDataHelper, 'getAgreementData')
+        .mockResolvedValue(mockAgreementData)
+
+      jest
+        .spyOn(getHTMLAgreement, 'getHTMLAgreementDocument')
+        .mockResolvedValue(mockRenderedHtml)
+    })
+
+    test('Should return 401 when no JWT token provided', async () => {
+      // Act
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789'
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.unauthorized)
+      expect(result).toEqual({
+        message: 'Not authorized to view offer agreement document'
+      })
+    })
+
+    test('Should return 401 when invalid JWT token provided', async () => {
+      // Arrange
+      const mockDecodedToken = { decoded: { payload: null } }
+      Jwt.token.decode = jest.fn().mockReturnValue(mockDecodedToken)
+      Jwt.token.verify = jest.fn().mockImplementation(() => {
+        throw new Error('Invalid token format')
+      })
+
+      // Act
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789',
+        headers: {
+          'x-encrypted-auth': 'invalid-token'
+        }
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.unauthorized)
+      expect(result).toEqual({
+        message: 'Not authorized to view offer agreement document'
+      })
+      expect(Jwt.token.decode).toHaveBeenCalledWith('invalid-token')
+      expect(Jwt.token.verify).toHaveBeenCalledWith(mockDecodedToken, {
+        key: expect.any(String),
+        algorithms: ['HS256']
+      })
+    })
+
+    test('Should authorize Entra users regardless of SBI match', async () => {
+      // Arrange
+      const mockDecodedToken = {
+        decoded: {
+          payload: {
+            sbi: 'different-sbi',
+            source: 'entra'
+          }
+        }
+      }
+      Jwt.token.decode = jest.fn().mockReturnValue(mockDecodedToken)
+      Jwt.token.verify = jest.fn().mockImplementation(() => Promise.resolve())
+
+      // Act
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789',
+        headers: {
+          'x-encrypted-auth': 'valid-jwt-token'
+        }
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should authorize Defra users with matching SBI', async () => {
+      // Arrange
+      const mockDecodedToken = {
+        decoded: {
+          payload: {
+            sbi: '123456789', // matches mockAgreementData.sbi
+            source: 'defra'
+          }
+        }
+      }
+      Jwt.token.decode = jest.fn().mockReturnValue(mockDecodedToken)
+      Jwt.token.verify = jest.fn().mockImplementation(() => Promise.resolve())
+
+      // Act
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789',
+        headers: {
+          'x-encrypted-auth': 'defra-jwt-token'
+        }
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('Should return 401 for Defra users with non-matching SBI', async () => {
+      // Arrange
+      const mockDecodedToken = {
+        decoded: {
+          payload: {
+            sbi: 'different-sbi',
+            source: 'defra'
+          }
+        }
+      }
+      Jwt.token.decode = jest.fn().mockReturnValue(mockDecodedToken)
+      Jwt.token.verify = jest.fn().mockImplementation(() => Promise.resolve())
+
+      // Act
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789',
+        headers: {
+          'x-encrypted-auth': 'defra-jwt-token'
+        }
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.unauthorized)
+      expect(result).toEqual({
+        message: 'Not authorized to view offer agreement document'
+      })
+    })
+
+    test('Should return 401 for unknown source type', async () => {
+      // Arrange
+      const mockDecodedToken = {
+        decoded: {
+          payload: {
+            sbi: '123456789',
+            source: 'unknown-source'
+          }
+        }
+      }
+      Jwt.token.decode = jest.fn().mockReturnValue(mockDecodedToken)
+      Jwt.token.verify = jest.fn().mockImplementation(() => Promise.resolve())
+
+      // Act
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789',
+        headers: {
+          'x-encrypted-auth': 'unknown-source-jwt-token'
+        }
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.unauthorized)
+      expect(result).toEqual({
+        message: 'Not authorized to view offer agreement document'
+      })
+    })
+
+    test('Should return 401 when JWT payload is malformed', async () => {
+      // Arrange
+      const mockDecodedToken = {
+        decoded: {
+          payload: null
+        }
+      }
+      Jwt.token.decode = jest.fn().mockReturnValue(mockDecodedToken)
+      Jwt.token.verify = jest.fn().mockImplementation(() => Promise.resolve())
+
+      // Act
+      const { statusCode, result } = await server.inject({
+        method: 'GET',
+        url: '/view-agreement/SFI123456789',
+        headers: {
+          'x-encrypted-auth': 'malformed-jwt-token'
+        }
+      })
+
+      // Assert
+      expect(statusCode).toBe(statusCodes.unauthorized)
+      expect(result).toEqual({
+        message: 'Not authorized to view offer agreement document'
+      })
     })
   })
 })

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -158,6 +158,12 @@ const config = convict({
       env: 'WAIT_TIME_SECONDS'
     }
   },
+  jwtToken: {
+    doc: 'JWT token',
+    format: String,
+    default: 'default-agreements-jwt-token',
+    env: 'AGREEMENTS_JWT_TOKEN'
+  },
   mongoUri: {
     doc: 'URI for mongodb',
     format: String,


### PR DESCRIPTION
Decode the `x-encrypted-auth` header and then verify the decoded payload against the jwt secret

Resolves: FRPSSFI-185 FRPSSFI-238