### PR TITLE
Remove service name for now

### DIFF
--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -20,8 +20,7 @@
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk/",
     classes: "govuk-header--full-width-border",
-    containerClasses: "govuk-width-container",
-    serviceName: "Farming land grants agreement"
+    containerClasses: "govuk-width-container"
   }) }}
 
   {{ defraAccountBar({


### PR DESCRIPTION
The service name is not shown on the prototype, so this PR removes it for now