### PR TITLE
Make SNS max publish attempts configurable

### DIFF
--- a/src/api/common/helpers/sns-publisher.js
+++ b/src/api/common/helpers/sns-publisher.js
@@ -43,7 +43,7 @@ export async function publishEvent(
     data
   }
 
-  const maxAttempts = 3
+  const maxAttempts = config.get('aws.sns.maxAttempts')
   let attempt = 0
   let lastError
 

--- a/src/api/common/helpers/sns-publisher.test.js
+++ b/src/api/common/helpers/sns-publisher.test.js
@@ -30,6 +30,8 @@ describe('publishEvent', () => {
           return 'test-secret-key'
         case 'aws.sns.eventSource':
           return 'test-source'
+        case 'aws.sns.maxAttempts':
+          return 3
         default:
           return undefined
       }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -126,6 +126,12 @@ const config = convict({
         default: 'http://localhost:4566',
         env: 'SNS_ENDPOINT'
       },
+      maxAttempts: {
+        doc: 'AWS SNS max publish attempts before error',
+        format: Number,
+        default: 3,
+        env: 'SNS_MAX_ATTEMPTS'
+      },
       eventSource: {
         doc: 'AWS SNS Cloud event source for emitted events',
         format: String,


### PR DESCRIPTION
Currently we're unable to change the SNS max publish attempts setting once the app goes live. This PR adds an option to customise how many notification publish attempts happen on error before giving up.