### PR TITLE
Fix missing data & styling from HTML PDF

### DIFF
--- a/src/api/agreement/controllers/accept-offer.controller.js
+++ b/src/api/agreement/controllers/accept-offer.controller.js
@@ -68,9 +68,9 @@ async function getAgreementHtml(agreementData, request) {
     agreementData
   )
 
-  return nunjucksEnvironment.render('views/sfi-agreement.njk', {
+  return nunjucksEnvironment.render('views/sfi-agreement-pdf.njk', {
     ...context(request),
-    ...agreement
+    agreement
   })
 }
 

--- a/src/api/agreement/controllers/accept-offer.controller.test.js
+++ b/src/api/agreement/controllers/accept-offer.controller.test.js
@@ -250,11 +250,11 @@ describe('acceptOfferDocumentController', () => {
     })
 
     expect(nunjucksEnvironment.render).toHaveBeenCalledWith(
-      'views/sfi-agreement.njk',
+      'views/sfi-agreement-pdf.njk',
       expect.objectContaining({
-        ...mockAgreementData,
         baseUrl: '/',
-        serviceName: 'farming-grants-agreements-api'
+        serviceName: 'farming-grants-agreements-api',
+        agreement: mockAgreementData
       })
     )
 

--- a/src/api/agreement/controllers/view-agreement.controller.js
+++ b/src/api/agreement/controllers/view-agreement.controller.js
@@ -24,7 +24,6 @@ const viewAgreementController = {
       // Return the HTML response
       return h
         .view('views/sfi-agreement.njk', {
-          ...fullAgreementData,
           agreement: fullAgreementData
         })
         .type('text/html')

--- a/src/server/common/templates/views/sfi-agreement-pdf.njk
+++ b/src/server/common/templates/views/sfi-agreement-pdf.njk
@@ -1,0 +1,49 @@
+{% extends 'views/sfi-agreement.njk' %}
+{% block head %}
+<style>
+  body {
+    font-family: GDS Transport, Helvetica, Arial, sans-serif;
+  }
+
+  header {
+    margin-bottom: 15px;
+  }
+
+  .govuk-\!-display-none-print,
+  .govuk-skip-link,
+  .govuk-phase-banner,
+  #contents,
+  footer {
+    display: none;
+  }
+
+  dd {
+    margin-left: 0;
+    font-weight: bold;
+    font-size: 1.1em;
+  }
+
+  dt {
+    margin: 5px 0 15px 10px;
+    font-size: 1em;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  table,
+  th,
+  td {
+    border: 1px solid black;
+  }
+
+  th,
+  td {
+    padding: 8px;
+    text-align: left;
+  }
+</style>
+{% endblock %}
+{% block bodyEnd %}{% endblock %}

--- a/src/server/common/templates/views/sfi-agreement.njk
+++ b/src/server/common/templates/views/sfi-agreement.njk
@@ -104,8 +104,8 @@
             {{ govukTable({
                         captionClasses: "govuk-table__caption--m",
                         classes: "govuk-table--small-text-until-tablet",
-                        head: agreementLand.headings,
-                        rows: agreementLand.data
+                        head: agreement.agreementLand.headings,
+                        rows: agreement.agreementLand.data
                         }) }}
             <p class="govuk-body">
                 Please note that the Terms and Conditions contain separate obligations in relation to the "Agreement Land".
@@ -118,8 +118,8 @@
                 {{ govukTable({
                                 captionClasses: "govuk-table__caption--m",
                                 classes: "govuk-table--small-text-until-tablet",
-                                head: summaryOfActions.headings,
-                                rows: summaryOfActions.data
+                                head: agreement.summaryOfActions.headings,
+                                rows: agreement.summaryOfActions.data
                                 })
                 }}
             </table>
@@ -140,8 +140,8 @@
                 {{ govukTable({
                                 captionClasses: "govuk-table__caption--m",
                                 classes: "govuk-table--small-text-until-tablet",
-                                head: summaryOfPayments.headings,
-                                rows: summaryOfPayments.data
+                                head: agreement.summaryOfPayments.headings,
+                                rows: agreement.summaryOfPayments.data
                                 })
                 }}
             </table>
@@ -164,8 +164,8 @@
                 {{ govukTable({
                                 captionClasses: "govuk-table__caption--m",
                                 classes: "govuk-table--small-text-until-tablet",
-                                head: annualPaymentSchedule.headings,
-                                rows: annualPaymentSchedule.data
+                                head: agreement.annualPaymentSchedule.headings,
+                                rows: agreement.annualPaymentSchedule.data
                                 })
                 }}
             </table>


### PR DESCRIPTION
Some data and styling was missing when sending the HTML over to the PDF service to print.