### PR TITLE
Update GAS agreement create type

### DIFF
--- a/scripts/publish-accept.js
+++ b/scripts/publish-accept.js
@@ -17,7 +17,7 @@ async function publishTestEvent() {
     id: 'xxxx-xxxx-xxxx-xxxx',
     source: 'fg-gas-backend',
     specVersion: '1.0',
-    type: 'cloud.defra.dev.fg-gas-backend.application.approved',
+    type: 'cloud.defra.test.fg-gas-backend.agreement.create',
     datacontenttype: 'application/json',
     data: {
       clientRef: 'ref-1234',

--- a/scripts/send-sqs-message.sh
+++ b/scripts/send-sqs-message.sh
@@ -11,7 +11,7 @@ read -r -d '' MESSAGE << EOM
   "id":"xxxx-xxxx-xxxx-xxxx",
   "source":"fg-gas-backend",
   "specVersion":"1.0",
-  "type":"cloud.defra.dev.fg-gas-backend.application.approved",
+  "type":"cloud.defra.test.fg-gas-backend.agreement.create",
   "datacontenttype":"application/json",
   "data":{
     "clientRef":"ref-1234",

--- a/src/api/common/helpers/seed-database.js
+++ b/src/api/common/helpers/seed-database.js
@@ -10,7 +10,7 @@ async function publishSampleAgreementEvents(tableData, logger) {
       {
         topicArn:
           'arn:aws:sns:eu-west-2:000000000000:grant_application_approved',
-        type: 'io.onsite.agreement.application.approved',
+        type: 'cloud.defra.test.fg-gas-backend.agreement.create',
         time: new Date().toISOString(),
         data: row
       },

--- a/src/api/common/helpers/seed-database.test.js
+++ b/src/api/common/helpers/seed-database.test.js
@@ -149,7 +149,7 @@ describe('seedDatabase', () => {
         {
           topicArn:
             'arn:aws:sns:eu-west-2:000000000000:grant_application_approved',
-          type: 'io.onsite.agreement.application.approved',
+          type: 'cloud.defra.test.fg-gas-backend.agreement.create',
           time: expect.any(String),
           data: { agreementNumber: 'SFI123456789' }
         },

--- a/src/api/common/helpers/sqs-client.test.js
+++ b/src/api/common/helpers/sqs-client.test.js
@@ -93,7 +93,7 @@ describe('SQS Client', () => {
   describe('handleEvent', () => {
     it('should create agreement for application-approved events', async () => {
       const mockPayload = {
-        type: 'application.approved',
+        type: 'cloud.defra.test.fg-gas-backend.agreement.create',
         data: { id: '123', status: 'approved' }
       }
 

--- a/src/api/common/helpers/sqs-message-processor.js
+++ b/src/api/common/helpers/sqs-message-processor.js
@@ -9,7 +9,7 @@ import { createOffer } from '~/src/api/agreement/helpers/create-offer.js'
  * @returns {Promise<Agreement>}
  */
 export const handleEvent = async (notificationMessageId, payload, logger) => {
-  if (payload.type.indexOf('application.approved') !== -1) {
+  if (payload.type.indexOf('gas-backend.agreement.create') !== -1) {
     logger.info(`Creating agreement from event: ${notificationMessageId}`)
     const agreement = await createOffer(
       notificationMessageId,

--- a/src/api/common/helpers/sqs-message-processor.test.js
+++ b/src/api/common/helpers/sqs-message-processor.test.js
@@ -18,7 +18,7 @@ describe('SQS message processor', () => {
   describe('processMessage', () => {
     it('should process valid SNS message', async () => {
       const mockPayload = {
-        type: 'application.approved',
+        type: 'gas-backend.agreement.create',
         data: { id: '123' }
       }
       const message = {
@@ -75,7 +75,7 @@ describe('SQS message processor', () => {
   describe('handleEvent', () => {
     it('should create agreement for application-approved events', async () => {
       const mockPayload = {
-        type: 'application.approved',
+        type: 'cloud.defra.test.fg-gas-backend.agreement.create',
         data: { id: '123', status: 'approved' }
       }
 


### PR DESCRIPTION
GAS SNS message type has changed from `io.onsite.agreement.application.approved` to `cloud.defra.test.fg-gas-backend.agreement.create`