### PR TITLE
Add more detail to SQS error event logging

### DIFF
--- a/src/api/agreement/helpers/withdraw-offer.js
+++ b/src/api/agreement/helpers/withdraw-offer.js
@@ -20,7 +20,10 @@ async function withdrawOffer(clientRef) {
       }
     )
     .catch((error) => {
-      throw Boom.internal(error)
+      throw Boom.internal(
+        'Offer is not in the correct state to be withdrawn or was not found',
+        error
+      )
     })
 
   return offer

--- a/src/api/agreement/helpers/withdraw-offer.test.js
+++ b/src/api/agreement/helpers/withdraw-offer.test.js
@@ -47,7 +47,10 @@ describe('withdrawOffer', () => {
     agreementModel.updateOneAgreementVersion.mockRejectedValueOnce(error)
 
     // Act & Assert
-    await expect(withdrawOffer(clientRef)).rejects.toThrow(Boom.internal(error))
+    await expect(withdrawOffer(clientRef)).rejects.toThrow(
+      'Offer is not in the correct state to be withdrawn or was not found',
+      Boom.internal(error)
+    )
   })
 
   test('should handle different clientRef values', async () => {

--- a/src/api/common/helpers/sqs-message-processor/create-agreement.js
+++ b/src/api/common/helpers/sqs-message-processor/create-agreement.js
@@ -23,7 +23,7 @@ export const handleCreateAgreementEvent = async (
     return agreement
   }
 
-  throw new Error('Unrecognized event type')
+  throw new Error(`Unrecognized event type ${payload.type}`)
 }
 
 /**

--- a/src/api/common/helpers/sqs-message-processor/update-agreement.js
+++ b/src/api/common/helpers/sqs-message-processor/update-agreement.js
@@ -22,7 +22,7 @@ export const handleUpdateAgreementEvent = async (
     return version
   }
 
-  throw new Error('Unrecognized event type')
+  throw new Error(`Unrecognized event type: ${payload.type} (${data.status})`)
 }
 
 /**


### PR DESCRIPTION
Adds more detail to SNS error event logging to make is easier to spot why the SQS message processor failed.