### PR TITLE
SFIR-457 Fix the way we log errors on our application

### DIFF
--- a/src/api/agreement/controllers/accept-offer.controller.js
+++ b/src/api/agreement/controllers/accept-offer.controller.js
@@ -46,7 +46,7 @@ const acceptOfferController = {
         return error
       }
 
-      request.logger.error(`Error accepting offer: ${error}`)
+      request.logger.error(error, 'Error accepting offer')
       return h
         .response({
           message: 'Failed to accept offer',

--- a/src/api/agreement/controllers/display-accept-offer.controller.js
+++ b/src/api/agreement/controllers/display-accept-offer.controller.js
@@ -20,6 +20,7 @@ const displayAcceptOfferController = {
       }
 
       request.logger.error(
+        error,
         `Error displaying accept offer page: ${error.message}`
       )
       return h

--- a/src/api/agreement/controllers/download.controller.js
+++ b/src/api/agreement/controllers/download.controller.js
@@ -34,8 +34,7 @@ export const downloadController = async (request, h) => {
 
     if (!stream) {
       request.logger?.error(
-        { agreementId, version, key, bucket },
-        'Agreement PDF not found in S3 - Key: ' + key
+        `Agreement PDF not found in S3 ${JSON.stringify({ agreementId, version, key, bucket })}`
       )
       throw Boom.notFound('Agreement PDF not found')
     }
@@ -50,8 +49,8 @@ export const downloadController = async (request, h) => {
     }
 
     request.logger?.error(
-      { err, agreementId, version, key, bucket },
-      'Error retrieving agreement PDF from S3'
+      err,
+      `Error retrieving agreement PDF from S3 ${JSON.stringify({ agreementId, version, key, bucket })}`
     )
     throw Boom.badImplementation('Error retrieving agreement PDF')
   }

--- a/src/api/agreement/controllers/offer-withdrawn.controller.js
+++ b/src/api/agreement/controllers/offer-withdrawn.controller.js
@@ -18,6 +18,7 @@ const offerWithdrawnController = {
       }
 
       request.logger.error(
+        error,
         `Error displaying offer withdrawn page: ${error.message}`
       )
       return h

--- a/src/api/agreement/controllers/offer-withdrawn.controller.test.js
+++ b/src/api/agreement/controllers/offer-withdrawn.controller.test.js
@@ -69,6 +69,7 @@ describe('offerWithdrawnController', () => {
 
     // Assert
     expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(Error),
       'Error displaying offer withdrawn page: Template rendering failed'
     )
     expect(mockH.response).toHaveBeenCalledWith({
@@ -92,6 +93,7 @@ describe('offerWithdrawnController', () => {
 
     // Assert
     expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(Error),
       'Error displaying offer withdrawn page: undefined'
     )
     expect(mockH.response).toHaveBeenCalledWith({

--- a/src/api/agreement/controllers/review-offer.controller.js
+++ b/src/api/agreement/controllers/review-offer.controller.js
@@ -84,7 +84,7 @@ const reviewOfferController = {
       if (error.isBoom) {
         throw error
       }
-      request.logger.error(`Error fetching offer: ${error.message}`)
+      request.logger.error(error, `Error fetching offer: ${error.message}`)
       return h
         .response({
           message: 'Failed to fetch offer',

--- a/src/api/agreement/controllers/review-offer.controller.test.js
+++ b/src/api/agreement/controllers/review-offer.controller.test.js
@@ -953,6 +953,7 @@ describe('reviewOfferController', () => {
         expect.objectContaining({ message: 'Failed to fetch offer' })
       )
       expect(request.logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
         expect.stringContaining('Error fetching offer:')
       )
     })

--- a/src/api/agreement/controllers/view-agreement.controller.js
+++ b/src/api/agreement/controllers/view-agreement.controller.js
@@ -59,6 +59,7 @@ const viewAgreementController = {
       }
 
       request.logger.error(
+        error,
         `Error rendering agreement document: ${error.message}`
       )
       request.logger.error(error.stack)

--- a/src/api/common/helpers/jwt-auth.js
+++ b/src/api/common/helpers/jwt-auth.js
@@ -48,10 +48,7 @@ const extractJwtPayload = (authToken, logger) => {
 
     return payload
   } catch (jwtError) {
-    logger.error(
-      jwtError.stack,
-      `Invalid JWT token provided: ${jwtError.message}`
-    )
+    logger.error(jwtError, `Invalid JWT token provided: ${jwtError.message}`)
     return null
   }
 }

--- a/src/api/common/helpers/jwt-auth.test.js
+++ b/src/api/common/helpers/jwt-auth.test.js
@@ -74,7 +74,7 @@ describe('jwt-auth', () => {
 
       expect(result).toBeNull()
       expect(mockLogger.error).toHaveBeenCalledWith(
-        mockError.stack,
+        mockError,
         'Invalid JWT token provided: Invalid signature'
       )
     })

--- a/src/api/common/helpers/mongoose.js
+++ b/src/api/common/helpers/mongoose.js
@@ -34,13 +34,7 @@ export const mongooseDb = {
         )
 
         seedDatabase(server.logger).catch((err) => {
-          server.logger.error(
-            {
-              error: err.message,
-              stack: err.stack
-            },
-            'Error seeding database failed:'
-          )
+          server.logger.error(err, 'Error seeding database failed:')
         })
       }
 

--- a/src/api/common/helpers/mongoose.test.js
+++ b/src/api/common/helpers/mongoose.test.js
@@ -131,10 +131,7 @@ describe('mongooseDb', () => {
 
       // Assert
       expect(mockLogger.error).toHaveBeenCalledWith(
-        {
-          error: 'Seed failed',
-          stack: seedError.stack
-        },
+        seedError,
         'Error seeding database failed:'
       )
     })

--- a/src/api/common/helpers/sqs-client.js
+++ b/src/api/common/helpers/sqs-client.js
@@ -15,14 +15,7 @@ export const processMessage = async (callback, message, logger) => {
     const messageBody = JSON.parse(message.Body)
     await callback(message.MessageId, messageBody, logger)
   } catch (error) {
-    logger.error(
-      {
-        message,
-        error: error.message,
-        stack: error.stack
-      },
-      'Error processing message:'
-    )
+    logger.error(error, 'Error processing message:')
 
     if (error.name === 'SyntaxError') {
       throw Boom.badData('Invalid message format', {
@@ -71,12 +64,7 @@ export const createSqsClientPlugin = (tag, queueUrl, callback) => ({
             )
           } catch (error) {
             server.logger.error(
-              {
-                messageId: message.MessageId,
-                error: error.message,
-                stack: error.stack,
-                data: error.data
-              },
+              error,
               `Failed to process SQS (${tag}) message:`
             )
           }
@@ -91,23 +79,11 @@ export const createSqsClientPlugin = (tag, queueUrl, callback) => ({
       })
 
       sqsConsumer.on('error', (err) => {
-        server.logger.error(
-          {
-            error: err.message || err.toString(),
-            fullError: err
-          },
-          `SQS Consumer (${tag}) error:`
-        )
+        server.logger.error(err, `SQS Consumer (${tag}) error`)
       })
 
       sqsConsumer.on('processing_error', (err) => {
-        server.logger.error(
-          {
-            error: err.message,
-            stack: err.stack
-          },
-          `SQS Message (${tag}) processing error:`
-        )
+        server.logger.error(err, `SQS Message (${tag}) processing error`)
       })
 
       sqsConsumer.on('started', () => {

--- a/src/api/common/helpers/sqs-client.test.js
+++ b/src/api/common/helpers/sqs-client.test.js
@@ -223,9 +223,7 @@ describe('SQS Client', () => {
       await messageHandler(invalidMessage)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: invalidMessage
-        }),
+        expect.any(Error),
         'Error processing message:'
       )
     })
@@ -248,11 +246,8 @@ describe('SQS Client', () => {
       errorHandler(error)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          error: error.message,
-          fullError: error
-        }),
-        'SQS Consumer (test) error:'
+        error,
+        'SQS Consumer (test) error'
       )
     })
 
@@ -274,11 +269,8 @@ describe('SQS Client', () => {
       errorHandler(error)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          error: error.message,
-          stack: expect.any(String)
-        }),
-        'SQS Message (test) processing error:'
+        error,
+        'SQS Message (test) processing error'
       )
     })
 

--- a/src/api/common/helpers/sqs-message-processor/create-agreement.test.js
+++ b/src/api/common/helpers/sqs-message-processor/create-agreement.test.js
@@ -45,10 +45,7 @@ describe('SQS message processor', () => {
         processMessage(handleCreateAgreementEvent, message, mockLogger)
       ).rejects.toThrow('Invalid message format')
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message,
-          error: expect.any(String)
-        }),
+        expect.any(Error),
         expect.stringContaining('Error processing message')
       )
     })
@@ -64,10 +61,7 @@ describe('SQS message processor', () => {
         processMessage(handleCreateAgreementEvent, message, mockLogger)
       ).rejects.toThrow('Error processing SQS message')
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message,
-          error: expect.any(String)
-        }),
+        expect.any(Error),
         expect.stringContaining('Error processing message')
       )
     })

--- a/src/api/common/helpers/sqs-message-processor/update-agreement.test.js
+++ b/src/api/common/helpers/sqs-message-processor/update-agreement.test.js
@@ -44,10 +44,7 @@ describe('SQS message processor', () => {
         processMessage(handleUpdateAgreementEvent, message, mockLogger)
       ).rejects.toThrow('Invalid message format')
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message,
-          error: expect.any(String)
-        }),
+        expect.any(Error),
         expect.stringContaining('Error processing message')
       )
     })
@@ -63,10 +60,7 @@ describe('SQS message processor', () => {
         processMessage(handleUpdateAgreementEvent, message, mockLogger)
       ).rejects.toThrow('Error processing SQS message')
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message,
-          error: expect.any(String)
-        }),
+        expect.any(Error),
         expect.stringContaining('Error processing message')
       )
     })

--- a/src/api/test-endpoints/controllers/post-test-queue-message.controller.test.js
+++ b/src/api/test-endpoints/controllers/post-test-queue-message.controller.test.js
@@ -194,8 +194,8 @@ describe('postTestQueueMessageController', () => {
       h
     )
 
-    expect(res.output.statusCode).toBe(statusCodes.internalServerError)
-    expect(res.output.payload.message).toBe('An internal server error occurred')
+    expect(res.statusCode).toBe(statusCodes.internalServerError)
+    expect(res.payload.message).toBe('Failed to post test queue message')
 
     // Restore setTimeout
     global.setTimeout.mockRestore()

--- a/src/api/test-endpoints/controllers/post-test-unaccept-offer.controller.js
+++ b/src/api/test-endpoints/controllers/post-test-unaccept-offer.controller.js
@@ -26,7 +26,7 @@ const postTestUnacceptOfferController = {
         return error
       }
 
-      request.logger.error(error, 'Error unaccepting offer:')
+      request.logger.error(error, 'Error unaccepting offer')
       return h
         .response({
           message: 'Failed to unaccept offer',


### PR DESCRIPTION
Pino expects the log methods to be called with `(obj, string)` not `(string, obj)`.

Also the CDP Support OpenSearch Log ingester is not consuming our bespoke error logs as they don't conform with the default keys they are consuming from the Pino method.

https://portal.cdp-int.defra.cloud/documentation/how-to/logging.md#current-streamlined-ecs-schema-on-cdp