### PR TITLE
SFIR-457 Fix the way we log info in our application

### DIFF
--- a/src/api/agreement/controllers/download.controller.js
+++ b/src/api/agreement/controllers/download.controller.js
@@ -26,8 +26,7 @@ export const downloadController = async (request, h) => {
 
   try {
     request.logger?.info(
-      { agreementId, version, key, bucket },
-      'Attempting agreement PDF download'
+      `Attempting agreement PDF download: ${JSON.stringify({ agreementId, version, key, bucket })}`
     )
 
     const stream = await getPdfStream({ bucket, key })

--- a/src/api/common/helpers/jwt-auth.js
+++ b/src/api/common/helpers/jwt-auth.js
@@ -15,11 +15,10 @@ const extractJwtPayload = (authToken, logger) => {
   }
 
   logger.info(
-    {
+    `Attempting to decode JWT token: ${JSON.stringify({
       tokenLength: authToken.length,
       isJwtFormat: authToken.startsWith('eyJ') && authToken.includes('.')
-    },
-    'Attempting to decode JWT token:'
+    })}`
   )
 
   try {
@@ -37,12 +36,11 @@ const extractJwtPayload = (authToken, logger) => {
 
     if (payload) {
       logger.info(
-        {
+        `JWT payload extracted: ${JSON.stringify({
           hasSbi: !!payload.sbi,
           hasSource: !!payload.source,
           source: payload.source
-        },
-        'JWT payload extracted:'
+        })}`
       )
     }
 
@@ -86,14 +84,13 @@ const validateJwtAuthentication = (authToken, agreementData, logger) => {
   const isJwtEnabled = config.get('featureFlags.isJwtEnabled')
 
   logger.info(
-    {
+    `JWT Authentication Validation Start: ${JSON.stringify({
       isJwtEnabled,
       hasAuthToken: !!authToken,
       authTokenLength: authToken ? authToken.length : 0,
       agreementSbi: agreementData?.identifiers?.sbi,
       agreementNumber: agreementData?.agreementNumber
-    },
-    'JWT Authentication Validation Start:'
+    })}`
   )
 
   if (!isJwtEnabled) {
@@ -110,16 +107,15 @@ const validateJwtAuthentication = (authToken, agreementData, logger) => {
   }
 
   logger.info(
-    {
+    `JWT payload extracted successfully: ${JSON.stringify({
       payloadSbi: jwtPayload.sbi,
       payloadSource: jwtPayload.source,
       agreementSbi: agreementData?.identifiers?.sbi
-    },
-    'JWT payload extracted successfully:'
+    })}`
   )
 
   const validationResult = verifyJwtPayload(jwtPayload, agreementData)
-  logger.info(validationResult, 'JWT payload verification result:')
+  logger.info(`JWT payload verification result: ${validationResult}`)
 
   return validationResult
 }

--- a/src/api/common/helpers/payment-hub/index.js
+++ b/src/api/common/helpers/payment-hub/index.js
@@ -77,7 +77,7 @@ export const sendPaymentHubRequest = async (server, logger, body) => {
     logger &&
     typeof logger.info === 'function'
   ) {
-    logger.info(body, 'Payload to be sent to payment hub:')
+    logger.info(`Payload to be sent to payment hub: ${JSON.stringify(body)}`)
   }
 
   if (!config.get('paymentHub.keyName') || !config.get('paymentHub.key')) {


### PR DESCRIPTION
Pino expects the log methods to be called with `(obj, string)` not `(string, obj)`.

Also the CDP Support OpenSearch Log ingester is not consuming our bespoke JSON logs as they don't conform with the default keys they are consuming from the Pino method.

Therefore we have to do string interpolation and stringify our JSON payload in order to have it visible in CDP OpenSearch Logs