### PR TITLE
Add service version comment

### DIFF
--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -45,6 +45,7 @@ export function context(request) {
     featureFlags: config.get('featureFlags'),
     serviceName: config.get('serviceName'),
     serviceTitle: config.get('serviceTitle'),
+    serviceVersion: config.get('serviceVersion'),
     auth,
     breadcrumbs: [],
     navigation: buildNavigation(request),

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -120,6 +120,7 @@ describe('#context', () => {
         ],
         serviceName: cfg.get('serviceName'),
         serviceTitle: cfg.get('serviceTitle'),
+        serviceVersion: cfg.get('serviceVersion'),
         auth: {
           isAuthenticated: false,
           name: 'Unauthenticated user',
@@ -215,6 +216,7 @@ describe('#context', () => {
           ],
           serviceName: cfg.get('serviceName'),
           serviceTitle: cfg.get('serviceTitle'),
+          serviceVersion: cfg.get('serviceVersion'),
           auth: {
             isAuthenticated: false,
             name: 'Unauthenticated user',

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -107,4 +107,5 @@
 {% block bodyEnd %}
   <script type="module" src="{{ getAssetPath(baseUrl, 'application.js') }}"
   nonce="{{cspNonce}}"></script>
+  {% if serviceVersion %}<!-- {{ serviceVersion }} -->{% endif %}
 {% endblock %}


### PR DESCRIPTION
To make it easier to know which version of the app we're testing, this adds the service version tag as a comment to the bottom of the HTML.