### PR TITLE
SFIR-1172: update the audit logic and data structure to match the new audit schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ AWS_SECRET_ACCESS_KEY=test
 
 # SNS configuration
 TOPIC_ARN=arn:aws:sns:eu-west-2:000000000000:grant_application_approved_fifo.fifo
+SNS_TOPIC_ARN_AUDIT=arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_api
 
 # S3 bucket configuration
 S3_ENDPOINT=http://localhost:4568

--- a/compose.yml
+++ b/compose.yml
@@ -109,6 +109,7 @@ services:
       VIEW_AGREEMENT_URI: http://host.docker.internal:3555
       SNS_TOPIC_TYPE_AGREEMENT_STATUS_UPDATED: ${SNS_TOPIC_TYPE_AGREEMENT_STATUS_UPDATED:-io.onsite.agreement.status.updated}
       SNS_TOPIC_ARN_AGREEMENT_STATUS_UPDATED: ${SNS_TOPIC_ARN_AGREEMENT_STATUS_UPDATED:-arn:aws:sns:eu-west-2:000000000000:agreement_status_updated_fifo.fifo}
+      SNS_TOPIC_ARN_AUDIT: ${SNS_TOPIC_ARN_AUDIT:-arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_api}
       FILES_S3_BUCKET: ${FILES_S3_BUCKET:-farming-grants-agreements-pdf-bucket}
       FILES_S3_BASE_TERM_PREFIX: ${FILES_S3_BASE_TERM_PREFIX:-base}
       FILES_S3_EXTENDED_TERM_PREFIX: ${FILES_S3_EXTENDED_TERM_PREFIX:-extended}

--- a/compose/start-floci.sh
+++ b/compose/start-floci.sh
@@ -18,6 +18,14 @@ declare -A TOPICS=(
   [create_agreement_pdf_fifo.fifo]="agreement_status_updated_fifo.fifo"     # - Used to generate the PDF of the agreement
 )
 
+# Standard (non-FIFO) SNS topics we publish to
+STANDARD_TOPICS=(
+  fcp_audit_farming_grants_agreements_api
+  fcp_audit_farming_grants_agreements_ui
+  fcp_audit_farming_grants_agreements_pdf
+  fcp_audit_grants_payment_service
+)
+
 # Associative arrays for ARNs and URLs
 declare -A TOPIC_ARNS
 declare -A QUEUE_URLS
@@ -31,6 +39,12 @@ ENDPOINT="${AWS_ENDPOINT:-http://floci:4566}"
 run() {
   aws --endpoint-url "$ENDPOINT" "$@"
 }
+
+# Create standard SNS topics
+for topic_name in "${STANDARD_TOPICS[@]}"; do
+  arn="$(run sns create-topic --name "$topic_name" --query 'TopicArn' --output text)"
+  echo "✅ Created standard topic: $arn"
+done
 
 # Create SNS topics
 for key in "${!TOPICS[@]}"; do

--- a/src/api/common/helpers/audit-event.js
+++ b/src/api/common/helpers/audit-event.js
@@ -1,3 +1,4 @@
+import { SNSClient, PublishCommand } from '@aws-sdk/client-sns'
 import { audit } from '@defra/cdp-auditing'
 import { config } from '#~/config/index.js'
 
@@ -40,17 +41,30 @@ const eventTypes = {
   [AuditEvent.AGREEMENT_UPDATED]: 'GrantsUpdateAgreement'
 }
 
-// Action for each audit event, used in audit.action
+// Action for each audit event, used in audit.entities[].action
 const eventActions = {
   [AuditEvent.PDF_DOWNLOADED_FROM_S3]: 'read',
   [AuditEvent.AGREEMENT_CREATED]: 'created',
   [AuditEvent.AGREEMENT_UPDATED]: 'updated'
 }
 
+const snsClient = new SNSClient(
+  process.env.NODE_ENV === 'development'
+    ? {
+        region: config.get('aws.region'),
+        endpoint: config.get('aws.sns.endpoint'),
+        credentials: {
+          accessKeyId: config.get('aws.accessKeyId'),
+          secretAccessKey: config.get('aws.secretAccessKey')
+        }
+      }
+    : {}
+)
+
 /**
  * Builds the full audit payload for an agreement operation.
  * @param {AuditEvent} event
- * @param {{ agreementNumber: string, correlationId?: string }} context
+ * @param {{ agreementNumber?: string, correlationId?: string, sbi?: string|number, frn?: string|number, crn?: string|number }} context
  * @param {'success'|'failure'} status
  */
 const buildAuditPayload = (event, context = {}, status = 'success') => ({
@@ -73,9 +87,18 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
 
   audit: {
     eventtype: eventTypes[event],
-    action: eventActions[event],
-    entity: 'agreement',
-    entityid: context.agreementNumber,
+    entities: [
+      {
+        entity: 'agreement',
+        action: eventActions[event],
+        id: context.agreementNumber
+      }
+    ],
+    accounts: {
+      sbi: context.sbi,
+      frn: context.frn,
+      crn: context.crn
+    },
     status,
     details: context
   }
@@ -84,9 +107,27 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
 /**
  * Records an agreement operation audit event.
  * @param {AuditEvent} event
- * @param {{ agreementNumber: string, correlationId?: string }} context
+ * @param {{ agreementNumber?: string, correlationId?: string, sbi?: string|number, frn?: string|number, crn?: string|number }} context
  * @param {'success'|'failure'} [status]
+ * @param {object} [client] - SNS client, injectable for testing
  */
-export const auditEvent = (event, context = {}, status = 'success') => {
-  audit(buildAuditPayload(event, context, status))
+export const auditEvent = (
+  event,
+  context = {},
+  status = 'success',
+  client = snsClient
+) => {
+  const payload = buildAuditPayload(event, context, status)
+  audit(payload)
+
+  client
+    .send(
+      new PublishCommand({
+        TopicArn: config.get('aws.sns.topic.audit.arn'),
+        Message: JSON.stringify(payload)
+      })
+    )
+    .catch(() => {
+      // fire and forget — SNS publish failure must not block the caller
+    })
 }

--- a/src/api/common/helpers/audit-event.js
+++ b/src/api/common/helpers/audit-event.js
@@ -40,6 +40,13 @@ const eventTypes = {
   [AuditEvent.AGREEMENT_UPDATED]: 'GrantsUpdateAgreement'
 }
 
+// Action for each audit event, used in audit.action
+const eventActions = {
+  [AuditEvent.PDF_DOWNLOADED_FROM_S3]: 'read',
+  [AuditEvent.AGREEMENT_CREATED]: 'created',
+  [AuditEvent.AGREEMENT_UPDATED]: 'updated'
+}
+
 /**
  * Builds the full audit payload for an agreement operation.
  * @param {AuditEvent} event
@@ -66,8 +73,8 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
 
   audit: {
     eventtype: eventTypes[event],
-    action: event,
-    entity: 'Agreements',
+    action: eventActions[event],
+    entity: 'agreement',
     entityid: context.agreementNumber,
     status,
     details: context

--- a/src/api/common/helpers/audit-event.test.js
+++ b/src/api/common/helpers/audit-event.test.js
@@ -117,8 +117,8 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsDownloadAgreement',
-          action: 'PDF_DOWNLOADED_FROM_S3',
-          entity: 'Agreements',
+          action: 'read',
+          entity: 'agreement',
           entityid: 'FPTT123456789',
           status: 'success',
           details: context
@@ -197,8 +197,8 @@ describe('auditEvent - AGREEMENT_CREATED', () => {
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsCreateAgreement',
-          action: 'AGREEMENT_CREATED',
-          entity: 'Agreements',
+          action: 'created',
+          entity: 'agreement',
           entityid: 'FPTT123456789',
           status: 'success',
           details: context
@@ -256,8 +256,8 @@ describe('auditEvent - AGREEMENT_UPDATED', () => {
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsUpdateAgreement',
-          action: 'AGREEMENT_UPDATED',
-          entity: 'Agreements',
+          action: 'updated',
+          entity: 'agreement',
           entityid: 'FPTT123456789',
           status: 'success',
           details: context

--- a/src/api/common/helpers/audit-event.test.js
+++ b/src/api/common/helpers/audit-event.test.js
@@ -4,7 +4,9 @@ const mockConfigGet = vi.hoisted(() =>
   vi.fn((key) => {
     const configMap = {
       env: 'test',
-      serviceName: 'farming-grants-agreements-api'
+      serviceName: 'farming-grants-agreements-api',
+      'aws.sns.topic.audit.arn':
+        'arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_api'
     }
     return configMap[key]
   })
@@ -12,11 +14,21 @@ const mockConfigGet = vi.hoisted(() =>
 
 vi.mock('#~/config/index.js', () => ({ config: { get: mockConfigGet } }))
 
+const mockSnsClientConstructor = vi.hoisted(() => vi.fn())
+
+vi.mock('@aws-sdk/client-sns', () => ({
+  SNSClient: mockSnsClientConstructor,
+  PublishCommand: vi.fn()
+}))
+
 describe('AuditEvent', () => {
   let AuditEvent
 
   beforeEach(async () => {
     vi.resetModules()
+    mockSnsClientConstructor.mockImplementation(function () {
+      return { send: vi.fn().mockResolvedValue({}) }
+    })
     vi.doMock('@defra/cdp-auditing', () => ({ audit: vi.fn() }))
     ;({ AuditEvent } = await import('./audit-event.js'))
   })
@@ -48,9 +60,14 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
   let audit
   let auditEvent
   let AuditEvent
+  let mockSnsClient
 
   beforeEach(async () => {
     vi.resetModules()
+    mockSnsClient = { send: vi.fn().mockResolvedValue({}) }
+    mockSnsClientConstructor.mockImplementation(function () {
+      return mockSnsClient
+    })
     vi.doMock('@defra/cdp-auditing', () => ({ audit: vi.fn() }))
     ;({ auditEvent, AuditEvent } = await import('./audit-event.js'))
     ;({ audit } = await import('@defra/cdp-auditing'))
@@ -70,7 +87,12 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, context)
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      context,
+      'success',
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -84,9 +106,12 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
   })
 
   test('calls audit with correct security fields', () => {
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, {
-      agreementNumber: 'FPTT123456789'
-    })
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -111,15 +136,21 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, context)
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      context,
+      'success',
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsDownloadAgreement',
-          action: 'read',
-          entity: 'agreement',
-          entityid: 'FPTT123456789',
+          entities: [
+            { entity: 'agreement', action: 'read', id: 'FPTT123456789' }
+          ],
+          accounts: { sbi: undefined, frn: undefined, crn: undefined },
           status: 'success',
           details: context
         })
@@ -127,8 +158,32 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
     )
   })
 
+  test('includes accounts when sbi/frn/crn are provided in context', () => {
+    const context = {
+      agreementNumber: 'FPTT123456789',
+      sbi: 123456789,
+      frn: 9876543210,
+      crn: 'CRN001'
+    }
+
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      context,
+      'success',
+      mockSnsClient
+    )
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          accounts: { sbi: 123456789, frn: 9876543210, crn: 'CRN001' }
+        })
+      })
+    )
+  })
+
   test('passes failure status through to the audit payload', () => {
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, {}, 'failure')
+    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, {}, 'failure', mockSnsClient)
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -138,14 +193,50 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
   })
 
   test('handles empty context gracefully', () => {
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3)
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      undefined,
+      'success',
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
         correlationid: undefined,
-        audit: expect.objectContaining({ entityid: undefined })
+        audit: expect.objectContaining({
+          entities: [{ entity: 'agreement', action: 'read', id: undefined }]
+        })
       })
     )
+  })
+
+  test('publishes audit payload to SNS topic', () => {
+    const context = {
+      agreementNumber: 'FPTT123456789',
+      correlationId: 'corr-xyz'
+    }
+
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      context,
+      'success',
+      mockSnsClient
+    )
+
+    expect(mockSnsClient.send).toHaveBeenCalledWith(expect.any(Object))
+  })
+
+  test('does not throw when SNS publish fails', () => {
+    mockSnsClient.send.mockRejectedValueOnce(new Error('SNS error'))
+
+    expect(() =>
+      auditEvent(
+        AuditEvent.PDF_DOWNLOADED_FROM_S3,
+        { agreementNumber: 'FPTT123456789' },
+        'success',
+        mockSnsClient
+      )
+    ).not.toThrow()
   })
 })
 
@@ -153,9 +244,14 @@ describe('auditEvent - AGREEMENT_CREATED', () => {
   let audit
   let auditEvent
   let AuditEvent
+  let mockSnsClient
 
   beforeEach(async () => {
     vi.resetModules()
+    mockSnsClient = { send: vi.fn().mockResolvedValue({}) }
+    mockSnsClientConstructor.mockImplementation(function () {
+      return mockSnsClient
+    })
     vi.doMock('@defra/cdp-auditing', () => ({ audit: vi.fn() }))
     ;({ auditEvent, AuditEvent } = await import('./audit-event.js'))
     ;({ audit } = await import('@defra/cdp-auditing'))
@@ -167,9 +263,12 @@ describe('auditEvent - AGREEMENT_CREATED', () => {
   })
 
   test('calls audit with correct security fields', () => {
-    auditEvent(AuditEvent.AGREEMENT_CREATED, {
-      agreementNumber: 'FPTT123456789'
-    })
+    auditEvent(
+      AuditEvent.AGREEMENT_CREATED,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -191,15 +290,16 @@ describe('auditEvent - AGREEMENT_CREATED', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.AGREEMENT_CREATED, context)
+    auditEvent(AuditEvent.AGREEMENT_CREATED, context, 'success', mockSnsClient)
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsCreateAgreement',
-          action: 'created',
-          entity: 'agreement',
-          entityid: 'FPTT123456789',
+          entities: [
+            { entity: 'agreement', action: 'created', id: 'FPTT123456789' }
+          ],
+          accounts: { sbi: undefined, frn: undefined, crn: undefined },
           status: 'success',
           details: context
         })
@@ -212,9 +312,14 @@ describe('auditEvent - AGREEMENT_UPDATED', () => {
   let audit
   let auditEvent
   let AuditEvent
+  let mockSnsClient
 
   beforeEach(async () => {
     vi.resetModules()
+    mockSnsClient = { send: vi.fn().mockResolvedValue({}) }
+    mockSnsClientConstructor.mockImplementation(function () {
+      return mockSnsClient
+    })
     vi.doMock('@defra/cdp-auditing', () => ({ audit: vi.fn() }))
     ;({ auditEvent, AuditEvent } = await import('./audit-event.js'))
     ;({ audit } = await import('@defra/cdp-auditing'))
@@ -226,9 +331,12 @@ describe('auditEvent - AGREEMENT_UPDATED', () => {
   })
 
   test('calls audit with correct security fields', () => {
-    auditEvent(AuditEvent.AGREEMENT_UPDATED, {
-      agreementNumber: 'FPTT123456789'
-    })
+    auditEvent(
+      AuditEvent.AGREEMENT_UPDATED,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -250,15 +358,16 @@ describe('auditEvent - AGREEMENT_UPDATED', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.AGREEMENT_UPDATED, context)
+    auditEvent(AuditEvent.AGREEMENT_UPDATED, context, 'success', mockSnsClient)
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsUpdateAgreement',
-          action: 'updated',
-          entity: 'agreement',
-          entityid: 'FPTT123456789',
+          entities: [
+            { entity: 'agreement', action: 'updated', id: 'FPTT123456789' }
+          ],
+          accounts: { sbi: undefined, frn: undefined, crn: undefined },
           status: 'success',
           details: context
         })

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -197,6 +197,15 @@ const config = convict({
             default: 'io.onsite.agreement.create-payment',
             env: 'SNS_TOPIC_TYPE_CREATE_PAYMENT'
           }
+        },
+        audit: {
+          arn: {
+            doc: 'AWS SNS Topic ARN for audit events',
+            format: String,
+            default:
+              'arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_api',
+            env: 'SNS_TOPIC_ARN_AUDIT'
+          }
         }
       }
     }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -29,6 +29,7 @@ export default defineConfig({
         '**test-helper**'
       ]
     },
+    hookTimeout: 30000,
     setupFiles: ['./.vitest/setup.js'],
     globalSetup: './.vitest/global-setup.js'
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/wiki/spaces/FDM/pages/6491670800/Audit+Schema+Refinement

- Replace `audit.entity/entityid/action` with `audit.entities` array of
  `{entity, action, id}` objects per updated audit service contract
- Add mandatory `audit.accounts` object with `sbi`, `frn`, `crn` fields
- Add SNS client and fire-and-forget publish to `fcp_audit_farming_grants_agreements_api` topic
- Wire `SNS_TOPIC_ARN_AUDIT` config key and update `.env.example`, `compose.yml`
- Create standard (non-FIFO) SNS topic in `start-floci.sh` for local dev
- Increase vitest `hookTimeout` to 30s to fix flaky server startup tests under load