### PR TITLE
SFIR-1171: pass request into auditEvent to extract client IP

### DIFF
--- a/src/api/agreement/controllers/accept-offer.controller.js
+++ b/src/api/agreement/controllers/accept-offer.controller.js
@@ -42,7 +42,8 @@ const acceptOfferController = async (request, h) => {
           correlationId: agreementData?.correlationId,
           message: err.message
         },
-        'failure'
+        'failure',
+        request
       )
       throw err
     }
@@ -70,10 +71,12 @@ const acceptOfferController = async (request, h) => {
       request.logger
     )
 
-    auditEvent(AuditEvent.AGREEMENT_CREATED, {
-      ...agreementData,
-      agreementNumber
-    })
+    auditEvent(
+      AuditEvent.AGREEMENT_CREATED,
+      { ...agreementData, agreementNumber },
+      'success',
+      request
+    )
   }
 
   // Return JSON response with agreement data

--- a/src/api/agreement/controllers/accept-offer.controller.test.js
+++ b/src/api/agreement/controllers/accept-offer.controller.test.js
@@ -205,7 +205,9 @@ describe('acceptOfferDocumentController', () => {
       expect.objectContaining({
         agreementNumber: 'FPTT123456789',
         status: 'accepted'
-      })
+      }),
+      'success',
+      expect.anything()
     )
   })
 
@@ -366,7 +368,8 @@ describe('acceptOfferDocumentController', () => {
         agreementNumber: 'FPTT123456789',
         message: 'Payment hub request failed'
       }),
-      'failure'
+      'failure',
+      expect.anything()
     )
   })
 })

--- a/src/api/agreement/controllers/download.controller.js
+++ b/src/api/agreement/controllers/download.controller.js
@@ -45,13 +45,18 @@ export const downloadController = async (request, h) => {
       throw Boom.notFound('Agreement PDF not found')
     }
 
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, {
-      agreementNumber: agreementId,
-      version,
-      key,
-      bucket,
-      correlationId: agreementData?.correlationId
-    })
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      {
+        agreementNumber: agreementId,
+        version,
+        key,
+        bucket,
+        correlationId: agreementData?.correlationId
+      },
+      'success',
+      request
+    )
 
     return h
       .response(stream)

--- a/src/api/common/helpers/audit-event.js
+++ b/src/api/common/helpers/audit-event.js
@@ -61,20 +61,31 @@ const snsClient = new SNSClient(
     : {}
 )
 
+const extractIp = (request) =>
+  request?.headers?.['x-forwarded-for']?.split(',')[0].trim() ||
+  request?.info?.remoteAddress ||
+  ''
+
 /**
  * Builds the full audit payload for an agreement operation.
  * @param {AuditEvent} event
  * @param {{ agreementNumber?: string, correlationId?: string, sbi?: string|number, frn?: string|number, crn?: string|number }} context
  * @param {'success'|'failure'} status
+ * @param {string} [ip]
  */
-const buildAuditPayload = (event, context = {}, status = 'success') => ({
+const buildAuditPayload = (
+  event,
+  context = {},
+  status = 'success',
+  ip = ''
+) => ({
   correlationid: context.correlationId,
   datetime: new Date().toISOString(),
   environment: config.get('env'),
   version: '0.1.0',
   application: 'Grants',
   component: config.get('serviceName'),
-
+  ip,
   security: {
     pmccode: eventPmcCodes[event],
     priority: '0',
@@ -109,15 +120,18 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
  * @param {AuditEvent} event
  * @param {{ agreementNumber?: string, correlationId?: string, sbi?: string|number, frn?: string|number, crn?: string|number }} context
  * @param {'success'|'failure'} [status]
+ * @param {object} [request] - Hapi request object, used to extract the originating client IP
  * @param {object} [client] - SNS client, injectable for testing
  */
 export const auditEvent = (
   event,
   context = {},
   status = 'success',
+  request = null,
   client = snsClient
 ) => {
-  const payload = buildAuditPayload(event, context, status)
+  const payload = buildAuditPayload(event, context, status, extractIp(request))
+
   audit(payload)
 
   client

--- a/src/api/common/helpers/audit-event.js
+++ b/src/api/common/helpers/audit-event.js
@@ -106,9 +106,9 @@ const buildAuditPayload = (
       }
     ],
     accounts: {
-      sbi: context.sbi,
-      frn: context.frn,
-      crn: context.crn
+      sbi: context.identifiers?.sbi,
+      frn: context.identifiers?.frn,
+      crn: context.identifiers?.crn
     },
     status,
     details: context

--- a/src/api/common/helpers/audit-event.test.js
+++ b/src/api/common/helpers/audit-event.test.js
@@ -164,9 +164,11 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
   test('includes accounts when sbi/frn/crn are provided in context', () => {
     const context = {
       agreementNumber: 'FPTT123456789',
-      sbi: 123456789,
-      frn: 9876543210,
-      crn: 'CRN001'
+      identifiers: {
+        sbi: 123456789,
+        frn: 9876543210,
+        crn: 'CRN001'
+      }
     }
 
     auditEvent(

--- a/src/api/common/helpers/audit-event.test.js
+++ b/src/api/common/helpers/audit-event.test.js
@@ -91,6 +91,7 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       AuditEvent.PDF_DOWNLOADED_FROM_S3,
       context,
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -110,6 +111,7 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       AuditEvent.PDF_DOWNLOADED_FROM_S3,
       { agreementNumber: 'FPTT123456789' },
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -140,6 +142,7 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       AuditEvent.PDF_DOWNLOADED_FROM_S3,
       context,
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -170,6 +173,7 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       AuditEvent.PDF_DOWNLOADED_FROM_S3,
       context,
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -183,7 +187,13 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
   })
 
   test('passes failure status through to the audit payload', () => {
-    auditEvent(AuditEvent.PDF_DOWNLOADED_FROM_S3, {}, 'failure', mockSnsClient)
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      {},
+      'failure',
+      undefined,
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -197,6 +207,7 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       AuditEvent.PDF_DOWNLOADED_FROM_S3,
       undefined,
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -220,10 +231,65 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
       AuditEvent.PDF_DOWNLOADED_FROM_S3,
       context,
       'success',
+      undefined,
       mockSnsClient
     )
 
     expect(mockSnsClient.send).toHaveBeenCalledWith(expect.any(Object))
+  })
+
+  test('extracts ip from x-forwarded-for header', () => {
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      { headers: { 'x-forwarded-for': '10.0.0.1' } },
+      mockSnsClient
+    )
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: '10.0.0.1' })
+    )
+  })
+
+  test('uses first ip when x-forwarded-for contains multiple addresses', () => {
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      { headers: { 'x-forwarded-for': '10.0.0.1, 10.0.0.2, 10.0.0.3' } },
+      mockSnsClient
+    )
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: '10.0.0.1' })
+    )
+  })
+
+  test('falls back to remoteAddress when x-forwarded-for is absent', () => {
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      { headers: {}, info: { remoteAddress: '192.168.1.1' } },
+      mockSnsClient
+    )
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: '192.168.1.1' })
+    )
+  })
+
+  test('defaults ip to empty string when no request provided', () => {
+    auditEvent(
+      AuditEvent.PDF_DOWNLOADED_FROM_S3,
+      { agreementNumber: 'FPTT123456789' },
+      'success',
+      undefined,
+      mockSnsClient
+    )
+
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ ip: '' }))
   })
 
   test('does not throw when SNS publish fails', () => {
@@ -234,6 +300,7 @@ describe('auditEvent - PDF_DOWNLOADED_FROM_S3', () => {
         AuditEvent.PDF_DOWNLOADED_FROM_S3,
         { agreementNumber: 'FPTT123456789' },
         'success',
+        undefined,
         mockSnsClient
       )
     ).not.toThrow()
@@ -267,6 +334,7 @@ describe('auditEvent - AGREEMENT_CREATED', () => {
       AuditEvent.AGREEMENT_CREATED,
       { agreementNumber: 'FPTT123456789' },
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -290,7 +358,13 @@ describe('auditEvent - AGREEMENT_CREATED', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.AGREEMENT_CREATED, context, 'success', mockSnsClient)
+    auditEvent(
+      AuditEvent.AGREEMENT_CREATED,
+      context,
+      'success',
+      undefined,
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -335,6 +409,7 @@ describe('auditEvent - AGREEMENT_UPDATED', () => {
       AuditEvent.AGREEMENT_UPDATED,
       { agreementNumber: 'FPTT123456789' },
       'success',
+      undefined,
       mockSnsClient
     )
 
@@ -358,7 +433,13 @@ describe('auditEvent - AGREEMENT_UPDATED', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.AGREEMENT_UPDATED, context, 'success', mockSnsClient)
+    auditEvent(
+      AuditEvent.AGREEMENT_UPDATED,
+      context,
+      'success',
+      undefined,
+      mockSnsClient
+    )
 
     expect(audit).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Extract originating IP from x-forwarded-for (first value) with fallback to request.info.remoteAddress, rather than passing a raw IP string.