### PR TITLE
FGP-1085: Relax validation schema for WMP

### DIFF
--- a/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.js
+++ b/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.js
@@ -1,19 +1,13 @@
 import Joi from 'joi'
 // UK postcode regex (allows optional space, both letter cases)
 const POSTCODE_RE = /^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$/i
-// Identifier digit lengths (DEFRA business reference standards)
-const SBI_DIGITS = 9
-const CRN_DIGITS = 10
-const FRN_DIGITS = 10
-const numericString = (digits) =>
-  Joi.string()
-    .pattern(new RegExp(String.raw`^\d{${digits}}$`))
-    .messages({
-      'string.pattern.base': `must be a ${digits}-digit numeric string`
-    })
+const externalIdentifier = Joi.alternatives().try(
+  Joi.string().trim().min(1),
+  Joi.number()
+)
 const positiveHectares = Joi.number().positive().precision(4)
 const moneyPence = Joi.number().integer().min(0)
-const HECTARES_TOLERANCE = 0.01
+const unmappedSourceField = Joi.any().optional()
 const landParcelSchema = Joi.object({
   parcelId: Joi.string().required(),
   areaHa: positiveHectares.required()
@@ -21,36 +15,14 @@ const landParcelSchema = Joi.object({
 const agreementPaymentItemSchema = Joi.object({
   code: Joi.string().required(),
   description: Joi.string().required(),
-  activePaymentTier: Joi.number().integer().min(1).optional(),
-  quantityInActiveTier: Joi.number().min(0).optional(),
-  activeTierRatePence: moneyPence.optional(),
-  activeTierFlatRatePence: moneyPence.optional(),
+  activePaymentTier: unmappedSourceField,
+  quantityInActiveTier: unmappedSourceField,
+  activeTierRatePence: unmappedSourceField,
+  activeTierFlatRatePence: unmappedSourceField,
   quantity: Joi.number().positive().precision(4).optional(),
   agreementTotalPence: moneyPence.required(),
   unit: Joi.string().optional()
 }).unknown(true)
-// `email` and `phone` arrive as objects on the real payload, but a string
-// form is also tolerated for forwards-compat with §3.1 of the plan.
-const emailField = Joi.alternatives().try(
-  Joi.string()
-    .email({ tlds: { allow: false } })
-    .allow(''),
-  Joi.object({
-    address: Joi.string()
-      .email({ tlds: { allow: false } })
-      .allow('')
-      .required()
-  }).unknown(true)
-)
-const phoneField = Joi.alternatives().try(
-  Joi.string().allow(''),
-  Joi.object({
-    landline: Joi.string().allow(''),
-    mobile: Joi.string().allow('')
-  })
-    .or('landline', 'mobile')
-    .unknown(true)
-)
 const addressSchema = Joi.object({
   line1: Joi.string().required(),
   line2: Joi.string().allow('', null),
@@ -62,21 +34,20 @@ const addressSchema = Joi.object({
   postalCode: Joi.string().pattern(POSTCODE_RE).required().messages({
     'string.pattern.base': 'must be a valid UK postcode'
   }),
-  // Optional PAF/UPRN fields carried verbatim
-  uprn: Joi.string().allow('', null),
-  buildingName: Joi.string().allow('', null),
-  buildingNumberRange: Joi.string().allow('', null),
-  county: Joi.string().allow('', null),
-  dependentLocality: Joi.string().allow('', null),
-  doubleDependentLocality: Joi.string().allow('', null),
-  flatName: Joi.string().allow('', null),
-  pafOrganisationName: Joi.string().allow('', null)
+  uprn: unmappedSourceField,
+  buildingName: unmappedSourceField,
+  buildingNumberRange: unmappedSourceField,
+  county: unmappedSourceField,
+  dependentLocality: unmappedSourceField,
+  doubleDependentLocality: unmappedSourceField,
+  flatName: unmappedSourceField,
+  pafOrganisationName: unmappedSourceField
 }).unknown(true)
 const businessSchema = Joi.object({
   name: Joi.string().required(),
-  reference: Joi.string().allow('', null),
-  email: emailField.optional(),
-  phone: phoneField.optional(),
+  reference: unmappedSourceField,
+  email: unmappedSourceField,
+  phone: unmappedSourceField,
   address: addressSchema.required()
 }).unknown(true)
 const customerSchema = Joi.object({
@@ -95,39 +66,20 @@ const applicantSchema = Joi.object({
 }).unknown(true)
 const metadataSchema = Joi.object({
   // The WMP payload sends an empty `metadata: {}` and puts identifiers at
-  // the top level — every field below is therefore optional.
+  // the top level.
   clientRef: Joi.string().optional(),
-  sbi: numericString(SBI_DIGITS).optional(),
-  crn: numericString(CRN_DIGITS).optional(),
-  frn: numericString(FRN_DIGITS).optional(),
-  submittedAt: Joi.date().iso().optional()
+  submittedAt: unmappedSourceField
 }).unknown(true)
 const identifiersSchema = Joi.object({
-  sbi: numericString(SBI_DIGITS).required(),
-  crn: numericString(CRN_DIGITS).required(),
-  frn: numericString(FRN_DIGITS).required(),
+  sbi: externalIdentifier.required(),
+  crn: externalIdentifier.required(),
+  frn: externalIdentifier.required(),
   defraId: Joi.string().allow('', null)
 }).unknown(true)
 
-// WMP cross-field rules:
-//  - existingWmps non-empty when appLandHasExistingWmp === true
-//  - totalAgreementPaymentPence (if present) equals sum of payments.agreement[].agreementTotalPence
-//  - totalHectaresForSelectedParcels (if landParcels present) equals sum of areaHa within tolerance
-function checkExistingWmps(answers) {
-  if (answers.appLandHasExistingWmp !== true) {
-    return null
-  }
-  const ew = answers.existingWmps
-  const empty =
-    ew == null ||
-    (typeof ew === 'string' && ew.trim() === '') ||
-    (Array.isArray(ew) && ew.length === 0)
-  if (empty) {
-    return 'existingWmps is required and must be non-empty when appLandHasExistingWmp is true'
-  }
-  return null
-}
-
+// WMP cross-field rule: totalAgreementPaymentPence equals the sum of
+// payments.agreement[].agreementTotalPence. Both values are mapped into the
+// agreement/payment event, so this remains part of the Agreements contract.
 function checkPaymentTotal(answers) {
   const items = answers.payments?.agreement
   if (!items?.length || answers.totalAgreementPaymentPence === undefined) {
@@ -146,32 +98,8 @@ function checkPaymentTotal(answers) {
   return null
 }
 
-function checkHectaresTotal(answers) {
-  if (!answers.landParcels?.length) {
-    return null
-  }
-  const sumHa = answers.landParcels.reduce(
-    (acc, p) => acc + Number(p.areaHa || 0),
-    0
-  )
-  if (
-    Math.abs(sumHa - answers.totalHectaresForSelectedParcels) >
-    HECTARES_TOLERANCE
-  ) {
-    return (
-      `totalHectaresForSelectedParcels (${answers.totalHectaresForSelectedParcels}) must equal ` +
-      `sum of landParcels[].areaHa (${sumHa.toFixed(4)}) within ±${HECTARES_TOLERANCE}`
-    )
-  }
-  return null
-}
-
 function crossFieldChecks(answers, helpers) {
-  const errors = [
-    checkExistingWmps(answers),
-    checkPaymentTotal(answers),
-    checkHectaresTotal(answers)
-  ].filter(Boolean)
+  const errors = [checkPaymentTotal(answers)].filter(Boolean)
 
   if (errors.length) {
     return helpers.message({ custom: errors.join('; ') })
@@ -179,34 +107,24 @@ function crossFieldChecks(answers, helpers) {
   return answers
 }
 const answersSchema = Joi.object({
-  businessDetailsUpToDate: Joi.boolean().strict().required(),
-  landRegisteredWithRpa: Joi.boolean().strict().required(),
-  landManagementControl: Joi.boolean().strict().required(),
-  publicBodyTenant: Joi.boolean().strict().required(),
-  landHasGrazingRights: Joi.boolean().strict().required(),
-  appLandHasExistingWmp: Joi.boolean().strict().required(),
-  // The real payload sends `existingWmps` as a string; keep array as a
-  // forwards-compat alternative.
-  existingWmps: Joi.alternatives()
-    .try(Joi.string().allow(''), Joi.array().items(Joi.any()))
-    .optional(),
-  intendToApplyHigherTier: Joi.boolean().strict().required(),
+  businessDetailsUpToDate: unmappedSourceField,
+  landRegisteredWithRpa: unmappedSourceField,
+  landManagementControl: unmappedSourceField,
+  publicBodyTenant: unmappedSourceField,
+  landHasGrazingRights: unmappedSourceField,
+  appLandHasExistingWmp: unmappedSourceField,
+  existingWmps: unmappedSourceField,
+  intendToApplyHigherTier: unmappedSourceField,
   hectaresTenOrOverYearsOld: Joi.number().min(0).precision(4).required(),
   hectaresUnderTenYearsOld: Joi.number().min(0).precision(4).required(),
-  centreGridReference: Joi.string().required(),
-  fcTeamCode: Joi.string().required(),
+  centreGridReference: unmappedSourceField,
+  fcTeamCode: unmappedSourceField,
   applicant: applicantSchema.required(),
-  detailsConfirmedAt: Joi.date().iso().required(),
-  totalHectaresForSelectedParcels: positiveHectares.required(),
-  guidanceRead: Joi.boolean().strict().valid(true).required().messages({
-    'any.only': 'guidanceRead must be true'
-  }),
-  includedAllEligibleWoodland: Joi.boolean().strict().required(),
-  applicationConfirmation: Joi.boolean()
-    .strict()
-    .valid(true)
-    .required()
-    .messages({ 'any.only': 'applicationConfirmation must be true' }),
+  detailsConfirmedAt: unmappedSourceField,
+  totalHectaresForSelectedParcels: unmappedSourceField,
+  guidanceRead: unmappedSourceField,
+  includedAllEligibleWoodland: unmappedSourceField,
+  applicationConfirmation: unmappedSourceField,
   // Optional fields preserved if upstream sends them
   agreementName: Joi.string().optional(),
   landParcels: Joi.array().items(landParcelSchema).min(1).required(),
@@ -226,7 +144,7 @@ const wmpCreateAgreementSchema = Joi.object({
   code: Joi.string().required(),
   scheme: Joi.string().optional(),
   metadata: metadataSchema.optional(),
-  identifiers: identifiersSchema.optional(),
+  identifiers: identifiersSchema.required(),
   answers: answersSchema.required()
 }).unknown(true)
 /**

--- a/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.test.js
+++ b/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.test.js
@@ -19,15 +19,41 @@ describe('wmpCreateAgreementSchema', () => {
   })
 
   describe('identifiers', () => {
-    it.each([
-      ['sbi', '20000000', 'must be a 9-digit numeric string'],
-      ['crn', 'abcdefghij', 'must be a 10-digit numeric string'],
-      ['frn', '123', 'must be a 10-digit numeric string']
-    ])('rejects malformed identifiers.%s', (field, badValue, msg) => {
+    it('allows non-numeric identifier values', () => {
       const p = clone(wmpFixture)
-      p.identifiers[field] = badValue
+      p.identifiers.sbi = 'sbi-from-source'
+      p.identifiers.frn = '106480734'
+      p.identifiers.crn = 'crn-from-source'
       const { error } = validateWmpCreateAgreement(p)
-      expect(error?.details.some((d) => d.message.includes(msg))).toBe(true)
+      expect(error).toBeUndefined()
+    })
+
+    it('rejects identifiers supplied only in metadata', () => {
+      const p = clone(wmpFixture)
+      p.identifiers = undefined
+      p.metadata = {
+        sbi: 'sbi-from-metadata',
+        frn: 'frn-from-metadata',
+        crn: 'crn-from-metadata'
+      }
+      const { error } = validateWmpCreateAgreement(p)
+      expect(error?.message).toMatch(/"identifiers" is required/)
+    })
+
+    it('rejects missing identifiers', () => {
+      const p = clone(wmpFixture)
+      delete p.identifiers.frn
+      const { error } = validateWmpCreateAgreement(p)
+      expect(error?.message).toMatch(/"identifiers.frn" is required/)
+    })
+
+    it('rejects blank identifiers', () => {
+      const p = clone(wmpFixture)
+      p.identifiers.sbi = '   '
+      const { error } = validateWmpCreateAgreement(p)
+      expect(error?.message).toMatch(
+        /"identifiers.sbi" is not allowed to be empty/
+      )
     })
   })
 
@@ -46,13 +72,13 @@ describe('wmpCreateAgreementSchema', () => {
         error?.details.some((d) => d.message.includes('valid UK postcode'))
       ).toBe(true)
     })
-    it('accepts email as object {address}', () => {
-      const { error } = validateWmpCreateAgreement(wmpFixture)
-      expect(error).toBeUndefined()
-    })
-    it('accepts email as plain string', () => {
+    it('allows source-only applicant fields without validating their shape', () => {
       const p = clone(wmpFixture)
-      p.answers.applicant.business.email = 'plain@example.test'
+      p.answers.applicant.business.reference = { unexpected: true }
+      p.answers.applicant.business.email = 'not-an-email'
+      p.answers.applicant.business.phone = { unexpected: true }
+      p.answers.applicant.business.address.uprn = { unexpected: true }
+      p.answers.applicant.business.address.flatName = 123
       const { error } = validateWmpCreateAgreement(p)
       expect(error).toBeUndefined()
     })
@@ -64,44 +90,47 @@ describe('wmpCreateAgreementSchema', () => {
     })
   })
 
-  describe('cross-field rules', () => {
-    it('rejects guidanceRead=false', () => {
+  describe('source-only answers', () => {
+    it('does not require answers that Agreements does not map or pass on', () => {
       const p = clone(wmpFixture)
-      p.answers.guidanceRead = false
-      const { error } = validateWmpCreateAgreement(p)
-      expect(error).toBeDefined()
-      expect(error.message).toMatch(/guidanceRead/)
-    })
-    it('rejects applicationConfirmation=false', () => {
-      const p = clone(wmpFixture)
-      p.answers.applicationConfirmation = false
-      const { error } = validateWmpCreateAgreement(p)
-      expect(error).toBeDefined()
-      expect(error.message).toMatch(/applicationConfirmation/)
-    })
-    it('rejects empty existingWmps when appLandHasExistingWmp=true', () => {
-      const p = clone(wmpFixture)
-      p.answers.appLandHasExistingWmp = true
-      p.answers.existingWmps = ''
-      const { error } = validateWmpCreateAgreement(p)
-      expect(error).toBeDefined()
-      expect(error.message).toMatch(/existingWmps/)
-    })
-    it('allows empty existingWmps when appLandHasExistingWmp=false', () => {
-      const p = clone(wmpFixture)
-      p.answers.appLandHasExistingWmp = false
-      p.answers.existingWmps = ''
+
+      for (const field of [
+        'businessDetailsUpToDate',
+        'landRegisteredWithRpa',
+        'landManagementControl',
+        'publicBodyTenant',
+        'landHasGrazingRights',
+        'appLandHasExistingWmp',
+        'existingWmps',
+        'intendToApplyHigherTier',
+        'centreGridReference',
+        'fcTeamCode',
+        'detailsConfirmedAt',
+        'totalHectaresForSelectedParcels',
+        'guidanceRead',
+        'includedAllEligibleWoodland',
+        'applicationConfirmation'
+      ]) {
+        delete p.answers[field]
+      }
+
       const { error } = validateWmpCreateAgreement(p)
       expect(error).toBeUndefined()
     })
-  })
 
-  describe('booleans are strict', () => {
-    it('rejects string "true" for businessDetailsUpToDate', () => {
+    it('does not validate the shape of source-only answers', () => {
       const p = clone(wmpFixture)
       p.answers.businessDetailsUpToDate = 'true'
+      p.answers.guidanceRead = false
+      p.answers.applicationConfirmation = false
+      p.answers.appLandHasExistingWmp = true
+      p.answers.existingWmps = ''
+      p.answers.detailsConfirmedAt = 'not-a-date'
+      p.answers.totalHectaresForSelectedParcels = { unexpected: true }
+      p.answers.centreGridReference = null
+
       const { error } = validateWmpCreateAgreement(p)
-      expect(error).toBeDefined()
+      expect(error).toBeUndefined()
     })
   })
 
@@ -161,12 +190,11 @@ describe('wmpCreateAgreementSchema', () => {
       expect(error.message).toMatch(/landParcels/)
     })
 
-    it('rejects when totalHectaresForSelectedParcels mismatches landParcels sum', () => {
+    it('does not validate totalHectaresForSelectedParcels against landParcels', () => {
       const p = clone(wmpFixture)
       p.answers.totalHectaresForSelectedParcels = 1
       const { error } = validateWmpCreateAgreement(p)
-      expect(error).toBeDefined()
-      expect(error.message).toMatch(/totalHectaresForSelectedParcels/)
+      expect(error).toBeUndefined()
     })
 
     it('rejects landParcel missing parcelId', () => {


### PR DESCRIPTION
Api is validating data that its not actually using, this change relaxes that validation.

- Replaced strict numerical identifier validation with support for alphanumeric values.
- Removed cross-field boolean checks and total hectares validations.
- Allowed unmapped source fields in applicant and address schemas.
- Updated tests to reflect new validation logic and permissiveness.