### PR TITLE
FGP-1101: Update WMP agreementName logic to use woodlandName

### DIFF
--- a/src/api/agreement/controllers/get-agreement.controller.test.js
+++ b/src/api/agreement/controllers/get-agreement.controller.test.js
@@ -1196,6 +1196,7 @@ describe('getAgreementController - Woodland Tests', () => {
         beforeEach(() => {
           mockAgreementData = {
             agreementNumber: 'WMP123456789',
+            agreementName: 'Oakridge Estate WMP',
             code: 'woodland',
             status: 'offered',
             sbi: '106284736',
@@ -1224,6 +1225,7 @@ describe('getAgreementController - Woodland Tests', () => {
           const { statusCode, result } = await doGet()
           expect(statusCode).toBe(statusCodes.ok)
           expect(result.agreementData.code).toBe('woodland')
+          expect(result.agreementData.agreementName).toBe('Oakridge Estate WMP')
           expect(result.agreementData.status).toContain('offered')
           expect(result.agreementData.schemeData).toEqual({
             oldWoodlandAreaHa: 0.4,

--- a/src/api/agreement/helpers/grant-types/wmp/wmp-create-offer.test.js
+++ b/src/api/agreement/helpers/grant-types/wmp/wmp-create-offer.test.js
@@ -68,6 +68,7 @@ describe('wmpCreateOffer (integration)', () => {
     const [version] = versions
     expect(version.status).toBe('offered')
     expect(version.scheme).toBe('WMP')
+    expect(version.agreementName).toBe('Oakridge Estate WMP')
     expect(version.notificationMessageId).toBe('sqs-msg-1')
     expect(version.payment.agreementTotalPence).toBe(
       wmpAgreementFixture.answers.totalAgreementPaymentPence

--- a/src/api/agreement/helpers/grant-types/wmp/wmp-payload-mapper.js
+++ b/src/api/agreement/helpers/grant-types/wmp/wmp-payload-mapper.js
@@ -125,7 +125,7 @@ function buildPaymentOrNull(ctx) {
 
 function buildVersionHeader(payload, meta, answers, correlationId, uuid) {
   return {
-    agreementName: answers.agreementName ?? 'Woodland Management Plan',
+    agreementName: `${answers.woodlandName.trim()} WMP`,
     correlationId: correlationId ?? uuid(),
     clientRef: payload.clientRef ?? meta.clientRef,
     code: payload.code,

--- a/src/api/agreement/helpers/grant-types/wmp/wmp-payload-mapper.test.js
+++ b/src/api/agreement/helpers/grant-types/wmp/wmp-payload-mapper.test.js
@@ -17,8 +17,44 @@ describe('mapWmpPayloadToVersion', () => {
     expect(result.clientRef).toBe(wmpFixture.clientRef)
     expect(result.code).toBe('woodland')
     expect(result.scheme).toBe('WMP')
-    expect(result.agreementName).toBe('Woodland Management Plan')
+    expect(result.agreementName).toBe('Oakridge Estate WMP')
     expect(result.status).toBe('offered')
+  })
+
+  it('builds the agreement name from the woodland name', () => {
+    const v = mapWmpPayloadToVersion(
+      {
+        ...wmpFixture,
+        answers: {
+          ...wmpFixture.answers,
+          woodlandName: 'Oakridge Estate'
+        }
+      },
+      {
+        notificationMessageId: 'm',
+        uuid: fixedUuid
+      }
+    )
+
+    expect(v.agreementName).toBe('Oakridge Estate WMP')
+  })
+
+  it('trims leading and trailing spaces from the woodland name', () => {
+    const v = mapWmpPayloadToVersion(
+      {
+        ...wmpFixture,
+        answers: {
+          ...wmpFixture.answers,
+          woodlandName: ' Oakridge Estate '
+        }
+      },
+      {
+        notificationMessageId: 'm',
+        uuid: fixedUuid
+      }
+    )
+
+    expect(v.agreementName).toBe('Oakridge Estate WMP')
   })
 
   it('takes identifiers from top-level identifiers', () => {
@@ -211,7 +247,7 @@ describe('mapWmpPayloadToVersion', () => {
       uuid: fixedUuid
     })
 
-    expect(v.agreementName).toBe('Woodland Management Plan')
+    expect(v.agreementName).toBe('Oakridge Estate WMP')
     expect(v.clientRef).toBe('wmp-from-metadata')
     expect(v.scheme).toBe('WMP')
     expect(v.payment.agreementStartDate).toBeNull()

--- a/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.js
+++ b/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.js
@@ -107,6 +107,7 @@ function crossFieldChecks(answers, helpers) {
   return answers
 }
 const answersSchema = Joi.object({
+  woodlandName: Joi.string().trim().min(1).required(),
   businessDetailsUpToDate: unmappedSourceField,
   landRegisteredWithRpa: unmappedSourceField,
   landManagementControl: unmappedSourceField,

--- a/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.test.js
+++ b/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.test.js
@@ -134,6 +134,24 @@ describe('wmpCreateAgreementSchema', () => {
     })
   })
 
+  describe('woodlandName', () => {
+    it('rejects missing woodlandName', () => {
+      const p = clone(wmpFixture)
+      delete p.answers.woodlandName
+      const { error } = validateWmpCreateAgreement(p)
+      expect(error?.message).toMatch(/"answers.woodlandName" is required/)
+    })
+
+    it('rejects woodlandName with only whitespace', () => {
+      const p = clone(wmpFixture)
+      p.answers.woodlandName = '   '
+      const { error } = validateWmpCreateAgreement(p)
+      expect(error?.message).toMatch(
+        /"answers.woodlandName" is not allowed to be empty/
+      )
+    })
+  })
+
   describe('payments', () => {
     it('accepts the fixture payment block', () => {
       const { error } = validateWmpCreateAgreement(wmpFixture)

--- a/src/api/common/helpers/sample-data/wmp-agreement.js
+++ b/src/api/common/helpers/sample-data/wmp-agreement.js
@@ -17,6 +17,7 @@ const wmpAgreement = {
   metadata: {},
   answers: {
     referenceNumber: 'WMP-926-WLW',
+    woodlandName: 'Oakridge Estate',
     businessDetailsUpToDate: true,
     landRegisteredWithRpa: true,
     landManagementControl: true,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1101

- Changed `agreementName` to use `woodlandName` with "WMP" suffix.
- Added `woodlandName` validation to ensure it is required, trimmed, and non-empty.
- Updated tests to reflect new `agreementName` construction and validation.