### PR TITLE
FGP-1149: Relax WMP address and payment validation

### DIFF
--- a/src/api/agreement/helpers/grant-types/wmp/wmp-payload-mapper.test.js
+++ b/src/api/agreement/helpers/grant-types/wmp/wmp-payload-mapper.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { mapWmpPayloadToVersion } from './wmp-payload-mapper.js'
 import wmpFixture from '#~/api/common/helpers/sample-data/wmp-agreement.js'
+import Version from '#~/api/common/models/versions.js'
 
 const fixedUuid = () => '00000000-0000-4000-8000-000000000000'
 
@@ -194,6 +195,19 @@ describe('mapWmpPayloadToVersion', () => {
     })
     expect(v.applicant.customer.name.title).toBeUndefined()
     expect(v.applicant.customer.name.middle).toBeUndefined()
+  })
+
+  it('allows missing applicant business address line1 through model validation', async () => {
+    const payload = JSON.parse(JSON.stringify(wmpFixture))
+    delete payload.answers.applicant.business.address.line1
+
+    const v = mapWmpPayloadToVersion(payload, {
+      notificationMessageId: 'm',
+      uuid: fixedUuid
+    })
+
+    expect(v.applicant.business.address.line1).toBeUndefined()
+    await expect(new Version(v).validate()).resolves.toBeUndefined()
   })
 
   it('uses crypto.randomUUID by default when no uuid generator injected', () => {

--- a/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.js
+++ b/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.js
@@ -1,6 +1,4 @@
 import Joi from 'joi'
-// UK postcode regex (allows optional space, both letter cases)
-const POSTCODE_RE = /^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$/i
 const externalIdentifier = Joi.alternatives().try(
   Joi.string().trim().min(1),
   Joi.number()
@@ -19,21 +17,19 @@ const agreementPaymentItemSchema = Joi.object({
   quantityInActiveTier: unmappedSourceField,
   activeTierRatePence: unmappedSourceField,
   activeTierFlatRatePence: unmappedSourceField,
-  quantity: Joi.number().positive().precision(4).optional(),
+  quantity: Joi.number().min(0).precision(4).optional(),
   agreementTotalPence: moneyPence.required(),
   unit: Joi.string().optional()
 }).unknown(true)
 const addressSchema = Joi.object({
-  line1: Joi.string().required(),
+  line1: Joi.string().allow('', null),
   line2: Joi.string().allow('', null),
   line3: Joi.string().allow('', null),
   line4: Joi.string().allow('', null),
   line5: Joi.string().allow('', null),
   street: Joi.string().allow('', null),
   city: Joi.string().required(),
-  postalCode: Joi.string().pattern(POSTCODE_RE).required().messages({
-    'string.pattern.base': 'must be a valid UK postcode'
-  }),
+  postalCode: Joi.string().required(),
   uprn: unmappedSourceField,
   buildingName: unmappedSourceField,
   buildingNumberRange: unmappedSourceField,

--- a/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.test.js
+++ b/src/api/agreement/helpers/schemas/wmp-create-agreement.schema.test.js
@@ -64,13 +64,11 @@ describe('wmpCreateAgreementSchema', () => {
       const { error } = validateWmpCreateAgreement(p)
       expect(error).toBeDefined()
     })
-    it('rejects invalid postcode', () => {
+    it('allows non-UK-format postcode to match GAS validation', () => {
       const p = clone(wmpFixture)
       p.answers.applicant.business.address.postalCode = 'NOT-A-POSTCODE'
       const { error } = validateWmpCreateAgreement(p)
-      expect(
-        error?.details.some((d) => d.message.includes('valid UK postcode'))
-      ).toBe(true)
+      expect(error).toBeUndefined()
     })
     it('allows source-only applicant fields without validating their shape', () => {
       const p = clone(wmpFixture)
@@ -81,6 +79,20 @@ describe('wmpCreateAgreementSchema', () => {
       p.answers.applicant.business.address.flatName = 123
       const { error } = validateWmpCreateAgreement(p)
       expect(error).toBeUndefined()
+    })
+    it('allows missing business.address.line1', () => {
+      const p = clone(wmpFixture)
+      delete p.answers.applicant.business.address.line1
+      const { error } = validateWmpCreateAgreement(p)
+      expect(error).toBeUndefined()
+    })
+    it('allows blank or null business.address.line1', () => {
+      for (const line1 of ['', null]) {
+        const p = clone(wmpFixture)
+        p.answers.applicant.business.address.line1 = line1
+        const { error } = validateWmpCreateAgreement(p)
+        expect(error).toBeUndefined()
+      }
     })
     it('rejects missing customer.name.first', () => {
       const p = clone(wmpFixture)
@@ -155,6 +167,13 @@ describe('wmpCreateAgreementSchema', () => {
   describe('payments', () => {
     it('accepts the fixture payment block', () => {
       const { error } = validateWmpCreateAgreement(wmpFixture)
+      expect(error).toBeUndefined()
+    })
+
+    it('accepts zero payment quantity to match GAS validation', () => {
+      const p = clone(wmpFixture)
+      p.answers.payments.agreement[0].quantity = 0
+      const { error } = validateWmpCreateAgreement(p)
       expect(error).toBeUndefined()
     })
 

--- a/src/api/common/models/versions.js
+++ b/src/api/common/models/versions.js
@@ -104,7 +104,7 @@ const Applicant = new mongoose.Schema({
       name: { type: String, required: true },
       address: {
         type: new mongoose.Schema({
-          line1: { type: String, required: true },
+          line1: { type: String },
           line2: { type: String },
           line3: { type: String },
           line4: { type: String },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1149

- Made `address.line1` optional and compatible with blank or null values.
- Removed strict UK postcode validation now just checking for a value.
- Allowed zero payment quantities to align with GAS validation.
- Updated tests to reflect new schema changes and flexibility.